### PR TITLE
feat: swappable fft backends, including torch and jax

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ test = [
     "zarr",
     "tifffile",
     "jax[cpu]",
+    "torch",
 ]
 dev = [
     "microsim[test]",

--- a/src/microsim/fft/backends.py
+++ b/src/microsim/fft/backends.py
@@ -1,0 +1,104 @@
+from abc import ABC, abstractmethod
+from collections.abc import Callable, Iterable
+from types import FunctionType, ModuleType
+from typing import Any
+
+
+class FFTBackend(ABC):
+    """Base class for FFT backends.
+
+    Implements https://uarray.org/en/latest/libauthor_docs.html
+    """
+
+    __ua_domain__ = "numpy.scipy.fft"
+
+    @abstractmethod
+    def fft_module(self) -> ModuleType:
+        raise NotImplementedError
+
+    @abstractmethod
+    def convert(self, value: Any, type: Any) -> Any:
+        raise NotImplementedError
+
+    def __ua_function__(self, method: FunctionType, args: Any, kwargs: Any) -> Any:
+        """Dispatch to the appropriate function in the backend module.
+
+        This defines the implementation of a multimethod. `method` is the multimethod
+        being called, and it is guaranteed that it is in the same domain as the backend.
+        `args` and `kwargs` are the arguments to the function, possibly after conversion
+        (explained below)
+
+        Returning NotImplemented signals that the backend does not support this
+        operation.
+        """
+        if fn := getattr(self.fft_module(), method.__name__, None):
+            return self.execute(fn, *args, **kwargs)
+        return NotImplemented
+
+    def __ua_convert__(self, dispatchables: Iterable, coerce: bool) -> Any:
+        """Convert dispatchables to the backend's array type.
+
+        https://uarray.org/en/latest/libauthor_docs.html
+
+        All dispatchable arguments are passed through `__ua_convert__` before being
+        passed into `__ua_function__`. `dispatchables` is iterable of Dispatchable and
+        `coerce` is whether or not to coerce forcefully. By convention, operations
+        larger than O(log n) (where n is the size of the object in memory) should only
+        be done if coerce is True. In addition, there are arguments wrapped as
+        non-coercible via the coercible attribute, if these must be coerced, then one
+        should return NotImplemented.
+
+        Returning NotImplemented signals that the backend does not support the
+        conversion of the given object.
+
+        """
+        if coerce:
+            return [self.convert(d.value, d.type) for d in dispatchables]
+        return NotImplemented
+
+    def execute(self, func: Callable, *args: Any, **kwargs: Any) -> Any:
+        return func(*args, **kwargs)
+
+
+class JaxFFTBackend(FFTBackend):
+    def __init__(self, device: Any = None) -> None:
+        try:
+            import jax
+        except ImportError as e:
+            raise ImportError("JaxFFTBackend requires JAX to be installed") from e
+        self.jax = jax
+        self.device = jax.devices(device)[0] if device else None
+
+    def fft_module(self) -> ModuleType:
+        return self.jax.numpy.fft
+
+    def convert(self, value: Any, type: type) -> Any:
+        result = self.jax.numpy.asarray(value)
+        if self.device:
+            result = self.jax.device_put(result, self.device)
+        return result
+
+
+class TorchFFTBackend(FFTBackend):
+    def __init__(self, device: Any = None) -> None:
+        try:
+            import torch
+        except ImportError as e:
+            raise ImportError("TorchFFTBackend requires torch to be installed") from e
+        self.torch = torch
+        self.device = device
+
+    def fft_module(self) -> ModuleType:
+        return self.torch.fft
+
+    def convert(self, value: Any, type: type) -> Any:
+        if self.device == "mps" and value.dtype.itemsize > 4:
+            dtype = self.torch.float32
+        else:
+            dtype = None
+        return self.torch.as_tensor(value, device=self.device, dtype=dtype)
+
+    def execute(self, func: Callable, *args: Any, **kwargs: Any) -> Any:
+        if "axes" in kwargs:
+            kwargs["dim"] = kwargs.pop("axes")
+        return func(*args, **kwargs)

--- a/src/microsim/fft/convolve.py
+++ b/src/microsim/fft/convolve.py
@@ -1,0 +1,33 @@
+from typing import Any, no_type_check
+from unittest.mock import patch
+
+import numpy.typing as npt
+from scipy.signal import fftconvolve
+from scipy.signal._signaltools import _centered
+
+
+@no_type_check
+def _apply_conv_mode_no_copy(ret, s1, s2, mode, axes):
+    # same as scipy.signal._signaltools._apply_conv_mode but without the .copy() call
+    if mode == "full":
+        return ret
+    elif mode == "same":
+        return _centered(ret, s1)
+    elif mode == "valid":
+        shape_valid = [
+            ret.shape[a] if a not in axes else s1[a] - s2[a] + 1
+            for a in range(ret.ndim)
+        ]
+        return _centered(ret, shape_valid)
+    raise ValueError("acceptable mode flags are 'valid'," " 'same', or 'full'")
+
+
+def patched_fftconvolve(
+    in1: Any, in2: Any, mode: str = "full", axes: int | npt.ArrayLike | None = None
+) -> Any:
+    # scipy.signal.fftconvolve assumes that all arraylike objects have a .copy() method
+    # which is not the case for some backends (like Torch).
+    # This function patches the _apply_conv_mode function to avoid calling .copy()
+    # after cropping the result to the desired shape.
+    with patch("scipy.signal._signaltools._apply_conv_mode", _apply_conv_mode_no_copy):
+        return fftconvolve(in1, in2, mode=mode, axes=axes)

--- a/tests/test_fftconv.py
+++ b/tests/test_fftconv.py
@@ -11,7 +11,7 @@ from microsim.fft.convolve import patched_fftconvolve
 np.random.seed(0)
 SHAPE = (128, 128, 128)
 ARY = np.random.rand(*SHAPE).astype(np.float32)
-KERNEL = np.ones((3, 3, 3)).astype(np.uint8)
+KERNEL = np.random.randint(0, 200, (3, 3, 3)).astype(np.uint8)
 EXPECTED = fftconvolve(ARY, KERNEL, mode="same")
 BACKENDS = {"scipy": "scipy", "jax": JaxFFTBackend(), "torch": TorchFFTBackend()}
 

--- a/tests/test_fftconv.py
+++ b/tests/test_fftconv.py
@@ -8,20 +8,12 @@ from scipy.signal import fftconvolve
 from microsim.fft.backends import JaxFFTBackend, TorchFFTBackend
 from microsim.fft.convolve import patched_fftconvolve
 
-# point source
 np.random.seed(0)
 SHAPE = (128, 128, 128)
 ARY = np.random.rand(*SHAPE).astype(np.float32)
-ARY[tuple(s // 2 for s in ARY.shape)] = 1
 KERNEL = np.ones((3, 3, 3)).astype(np.uint8)
 EXPECTED = fftconvolve(ARY, KERNEL, mode="same")
-
-
-BACKENDS = {
-    "scipy": "scipy",
-    "jax": JaxFFTBackend("cpu"),
-    "torch": TorchFFTBackend("cpu"),
-}
+BACKENDS = {"scipy": "scipy", "jax": JaxFFTBackend(), "torch": TorchFFTBackend()}
 
 
 @pytest.mark.parametrize("backend", ["scipy", "jax", "torch"])

--- a/tests/test_fftconv.py
+++ b/tests/test_fftconv.py
@@ -30,6 +30,7 @@ def test_fft_backend(backend: Any) -> None:
         result = patched_fftconvolve(ARY, KERNEL, mode="same")
 
     if hasattr(result, "cpu"):
+        # torch tensor ... required before calling assert_allclose
         result = result.cpu()
 
     np.testing.assert_allclose(result, EXPECTED, rtol=1e-2, atol=1e-2)

--- a/tests/test_fftconv.py
+++ b/tests/test_fftconv.py
@@ -33,4 +33,4 @@ def test_fft_backend(backend: Any) -> None:
         # torch tensor ... required before calling assert_allclose
         result = result.cpu()
 
-    np.testing.assert_allclose(result, EXPECTED, rtol=1e-2, atol=1e-2)
+    np.testing.assert_allclose(result, EXPECTED, rtol=1e-6)

--- a/tests/test_fftconv.py
+++ b/tests/test_fftconv.py
@@ -25,4 +25,7 @@ def test_fft_backend(backend: Any) -> None:
         # torch tensor ... required before calling assert_allclose
         result = result.cpu()
 
-    np.testing.assert_allclose(result, EXPECTED, rtol=1e-6)
+    # in many case this is accurate to 1e-6 tolerance, but it's os-dependent
+    # so we set the tolerance to 1e-5
+    TOL = 1e-5
+    np.testing.assert_allclose(result, EXPECTED, rtol=TOL)

--- a/tests/test_fftconv.py
+++ b/tests/test_fftconv.py
@@ -1,0 +1,35 @@
+from typing import Any
+
+import numpy as np
+import pytest
+import scipy.fft
+from scipy.signal import fftconvolve
+
+from microsim.fft.backends import JaxFFTBackend, TorchFFTBackend
+from microsim.fft.convolve import patched_fftconvolve
+
+# point source
+np.random.seed(0)
+SHAPE = (128, 128, 128)
+ARY = np.random.rand(*SHAPE).astype(np.float32)
+ARY[tuple(s // 2 for s in ARY.shape)] = 1
+KERNEL = np.ones((3, 3, 3)).astype(np.uint8)
+EXPECTED = fftconvolve(ARY, KERNEL, mode="same")
+
+
+BACKENDS = {
+    "scipy": "scipy",
+    "jax": JaxFFTBackend("cpu"),
+    "torch": TorchFFTBackend("cpu"),
+}
+
+
+@pytest.mark.parametrize("backend", ["scipy", "jax", "torch"])
+def test_fft_backend(backend: Any) -> None:
+    with scipy.fft.set_backend(BACKENDS[backend], coerce=True):
+        result = patched_fftconvolve(ARY, KERNEL, mode="same")
+
+    if hasattr(result, "cpu"):
+        result = result.cpu()
+
+    np.testing.assert_allclose(result, EXPECTED, rtol=1e-2, atol=1e-2)


### PR DESCRIPTION
This adds basic FFT backend implementations for Jax and Torch, so that one can use [`scipy.fft.set_backend`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.fft.set_backend.html) to switch between fft providers (making it easier to do fast fftconvolve with any backend).  

```python
    with scipy.fft.set_backend('torch', coerce=True):
        result = fftconvolve(in1, in2, mode="same")
```

see https://uarray.org/en/latest/libauthor_docs.html for background


This makes it easy to guarantee that the output is similar, since we let `scipy.signal.fftconvolve` do all the work of reshaping the arrays for various modes (which is one of the tricky things when trying to swap the backend without changing the result), *however* for cases where a backend already provides an  appropriate fftconvolve (like [jax](https://jax.readthedocs.io/en/latest/_autosummary/jax.scipy.signal.fftconvolve.html)), it may be slower.  This could be gated at the level of the `NumpyAPI` object here within microsim.  but this PR provides a higher level generic way to dispatch the important fft operations to a specific backend.

cc @ashesh-0 