### PR TITLE
feat: add pint quantities to more fields

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,4 @@ repos:
           - pydantic-settings
           - xarray
           - types-tqdm
+          - pint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     'pydantic-settings',
     "annotated_types",
     "numpy",
-    "pint",
+    "pint>=0.23",
     "pydantic>=2.4",
     "scipy",
     "tqdm",

--- a/src/microsim/_field_types.py
+++ b/src/microsim/_field_types.py
@@ -4,10 +4,11 @@ from inspect import signature
 from typing import TYPE_CHECKING, Annotated, Any, Literal, Protocol
 
 import numpy as np
+from pint.facets.plain import PlainQuantity
 from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler, functional_validators
 from pydantic_core import core_schema
 
-from . import _validators
+from .schema import _validators
 
 if TYPE_CHECKING:
     from pydantic.json_schema import JsonSchemaValue
@@ -130,6 +131,8 @@ class _NumpyNdarrayPydanticAnnotation:
 
 ######################### Custom Field Types #########################
 
+############### numpy stuff ###############
+
 Dtype = Annotated[np.dtype, BeforeValidator(_validators.validate_np_dtype)]
 FloatDtype = Annotated[
     np.dtype[np.floating], BeforeValidator(_validators.validate_np_floating_dtype)
@@ -139,3 +142,14 @@ IntDtype = Annotated[
 ]
 
 NumpyNdarray = Annotated[np.ndarray, _NumpyNdarrayPydanticAnnotation]
+
+############### pint stuff ###############
+
+# these are all ultimately also numeric and/or array[numeric] types too
+
+Meters = Annotated[PlainQuantity, BeforeValidator(_validators.validate_meters)]
+Microns = Annotated[PlainQuantity, BeforeValidator(_validators.validate_microns)]
+Nanometers = Annotated[PlainQuantity, BeforeValidator(_validators.validate_nm)]
+ExtCoeff = Annotated[PlainQuantity, BeforeValidator(_validators.validate_ext_coeff)]
+Nanoseconds = Annotated[PlainQuantity, BeforeValidator(_validators.validate_ns)]
+Seconds = Annotated[PlainQuantity, BeforeValidator(_validators.validate_seconds)]

--- a/src/microsim/fpbase.py
+++ b/src/microsim/fpbase.py
@@ -5,14 +5,16 @@ from urllib.request import Request, urlopen
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
+from microsim._field_types import ExtCoeff, Nanometers, Nanoseconds
+
 __all__ = ["get_fluorophore", "get_microscope", "FPbaseFluorophore", "FPbaseMicroscope"]
 
-FPBASE_URL = "https://www.fpbase.org/graphql/"
+
+### Models ###
+
 SpectrumType = Literal[
     "A_2P", "BM", "BP", "BS", "BX", "EM", "EX", "LP", "PD", "QE", "AB"
 ]
-
-### Models ###
 
 
 class Spectrum(BaseModel):
@@ -27,12 +29,12 @@ class SpectrumOwner(BaseModel):
 
 class State(BaseModel):
     id: int
-    exMax: float
-    emMax: float
-    extCoeff: float
+    exMax: Nanometers
+    emMax: Nanometers
+    extCoeff: ExtCoeff
     qy: float
     spectra: list[Spectrum]
-    lifetime: float | None = None
+    lifetime: Nanoseconds | None = None
 
     @property
     def excitation_spectrum(self) -> Spectrum | None:
@@ -115,7 +117,9 @@ class DyeResponse(BaseModel):
     data: DyePayload
 
 
-### Getter Functions ###
+### Graphql Queries ###
+
+FPBASE_URL = "https://www.fpbase.org/graphql/"
 
 
 @cache

--- a/src/microsim/psf.py
+++ b/src/microsim/psf.py
@@ -349,22 +349,19 @@ def make_psf(
     max_au_relative: float | None = None,
     xp: NumpyAPI | None = None,
 ) -> ArrayProtocol:
-    xp = NumpyAPI.create(xp)
     nz, _ny, nx = space.shape
     dz, _dy, dx = space.scale
-    ex_wvl_um = channel.excitation.bandcenter * 1e-3
-    em_wvl_um = channel.emission.bandcenter * 1e-3
     return cached_psf(
         nz=nz,
         nx=nx,
         dx=dx,
         dz=dz,
-        ex_wvl_um=ex_wvl_um,
-        em_wvl_um=em_wvl_um,
+        ex_wvl_um=channel.excitation.bandcenter.to("um").magnitude,
+        em_wvl_um=channel.emission.bandcenter.to("um").magnitude,
         objective=_cast_objective(objective),
         pinhole_au=pinhole_au,
         max_au_relative=max_au_relative,
-        xp=xp,
+        xp=NumpyAPI.create(xp),
     )
 
 

--- a/src/microsim/schema/_base_model.py
+++ b/src/microsim/schema/_base_model.py
@@ -4,4 +4,7 @@ from pydantic import BaseModel, ConfigDict
 
 
 class SimBaseModel(BaseModel):
-    model_config: ClassVar[ConfigDict] = {"validate_assignment": True}
+    model_config: ClassVar[ConfigDict] = ConfigDict(
+        validate_assignment=True,
+        validate_default=True,
+    )

--- a/src/microsim/schema/_validators.py
+++ b/src/microsim/schema/_validators.py
@@ -7,7 +7,7 @@ from typing import Any, TypeVar
 import numpy as np
 import pint
 from pint._typing import UnitLike
-from pint.facets.plain import MagnitudeT, PlainQuantity
+from pint.facets.plain.quantity import MagnitudeT, PlainQuantity
 
 T = TypeVar("T", bound=pint.Unit)
 

--- a/src/microsim/schema/_validators.py
+++ b/src/microsim/schema/_validators.py
@@ -1,8 +1,15 @@
 """Functions that return coerced/validated values."""
 
-from typing import Any
+from collections.abc import Callable
+from contextlib import suppress
+from typing import Any, TypeVar
 
 import numpy as np
+import pint
+from pint._typing import UnitLike
+from pint.facets.plain import MagnitudeT, PlainQuantity
+
+T = TypeVar("T", bound=pint.Unit)
 
 
 def validate_np_dtype(x: Any) -> np.dtype:
@@ -24,3 +31,31 @@ def validate_np_integer_dtype(x: Any) -> np.dtype[np.integer]:
     if not np.issubdtype(dt, np.floating):
         raise ValueError(f"Expected a integer dtype, got {dt}")
     return dt
+
+
+def make_unit_validator(units: UnitLike) -> Callable[[Any], PlainQuantity]:
+    """Return a function that casts a value to a pint.Quantity with the given units."""
+
+    def validate_unit(value: Any) -> PlainQuantity[MagnitudeT]:
+        """Cast a `value` to a pint.Quantity with the given units."""
+        quant: PlainQuantity = pint.Quantity(value)
+        if quant.dimensionless:
+            quant = pint.Quantity(value, units=units)
+        if not quant.check(units):
+            raise ValueError(f"Expected a quantity with units {units}, got {quant}")
+        with suppress(pint.UndefinedUnitError):
+            # try to cast to the given units.
+            # This may fail, even if quant.check() passed, if `units` is just a dimenson
+            quant = quant.to(units)
+        return quant
+
+    return validate_unit
+
+
+validate_meters = make_unit_validator("meter")
+validate_microns = make_unit_validator("um")
+validate_nm = make_unit_validator("nm")
+validate_ext_coeff = make_unit_validator("1 / M / cm")
+
+validate_ns = make_unit_validator("ns")
+validate_seconds = make_unit_validator("second")

--- a/src/microsim/schema/lens.py
+++ b/src/microsim/schema/lens.py
@@ -3,6 +3,8 @@ from typing import Any, TypedDict
 import numpy as np
 from pydantic import Field, model_validator
 
+from microsim._field_types import Microns
+
 from ._base_model import SimBaseModel
 
 
@@ -26,9 +28,12 @@ class ObjectiveLens(SimBaseModel):
     immersion_medium_ri: float = 1.515  # immersion medium RI experimental value (ni)
     immersion_medium_ri_spec: float = 1.515  # immersion medium RI design value (ni0)
     specimen_ri: float = 1.47  # specimen refractive index (ns)
-    working_distance: float = 150.0  # um, working distance, design value (ti0)
-    coverslip_thickness: float = 170.0  # um, coverslip thickness (tg)
-    coverslip_thickness_spec: float = 170.0  # um, coverslip thickness design (tg0)
+    # um, working distance, design value (ti0)
+    working_distance: Microns = 150.0  # type: ignore
+    # um, coverslip thickness (tg)
+    coverslip_thickness: Microns = 170.0  # type: ignore
+    # um, coverslip thickness design (tg0)
+    coverslip_thickness_spec: Microns = 170.0  # type: ignore
 
     magnification: float = Field(1, description="magnification of objective lens.")
 
@@ -78,15 +83,15 @@ class ObjectiveLens(SimBaseModel):
 
     @property
     def tg(self) -> float:
-        return self.coverslip_thickness * 1e-6
+        return float(self.coverslip_thickness.to("meters").magnitude)
 
     @property
     def tg0(self) -> float:
-        return self.coverslip_thickness_spec * 1e-6
+        return float(self.coverslip_thickness_spec.to("meters").magnitude)
 
     @property
     def ti0(self) -> float:
-        return self.working_distance * 1e-6
+        return float(self.working_distance.to("meters").magnitude)
 
     @property
     def ng0(self) -> float:

--- a/src/microsim/schema/optical_config/filter.py
+++ b/src/microsim/schema/optical_config/filter.py
@@ -1,7 +1,12 @@
-from typing import Literal
+from typing import Annotated, Literal
 
+from annotated_types import Interval
+
+from microsim._field_types import Nanometers
 from microsim.schema._base_model import SimBaseModel
 from microsim.schema.spectrum import Spectrum
+
+Transmission = Annotated[float, Interval(ge=0, le=1.0)]
 
 
 class _Filter(SimBaseModel):
@@ -11,30 +16,30 @@ class _Filter(SimBaseModel):
 
 class Bandpass(_Filter):
     type: Literal["bandpass"] = "bandpass"
-    bandcenter: float
-    bandwidth: float
-    transmission: float = 1.0
+    bandcenter: Nanometers
+    bandwidth: Nanometers
+    transmission: Transmission = 1.0
 
 
 class Shortpass(_Filter):
     type: Literal["shortpass"] = "shortpass"
-    cutoff: float
+    cutoff: Nanometers
     slope: float = 1.0
-    transmission: float = 1.0
+    transmission: Transmission = 1.0
 
     @property
-    def bandcenter(self) -> float:
+    def bandcenter(self) -> Nanometers:
         return self.cutoff
 
 
 class Longpass(_Filter):
     type: Literal["longpass"] = "longpass"
-    cutoff: float
+    cutoff: Nanometers
     slope: float = 1.0
-    transmission: float = 1.0
+    transmission: Transmission = 1.0
 
     @property
-    def bandcenter(self) -> float:
+    def bandcenter(self) -> Nanometers:
         return self.cutoff
 
 
@@ -43,7 +48,7 @@ class FilterSpectrum(_Filter):
     spectrum: Spectrum
 
     @property
-    def bandcenter(self) -> float:
+    def bandcenter(self) -> Nanometers:
         return self.spectrum.peak_wavelength
 
 

--- a/src/microsim/schema/sample/fluorophore.py
+++ b/src/microsim/schema/sample/fluorophore.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from pydantic import model_validator
 
+from microsim._field_types import ExtCoeff, Nanoseconds, Seconds
 from microsim.schema._base_model import SimBaseModel
 from microsim.schema.spectrum import Spectrum
 
@@ -10,10 +11,10 @@ class Fluorophore(SimBaseModel):
     name: str
     excitation_spectrum: Spectrum
     emission_spectrum: Spectrum
-    bleaching_half_life_s: float | None = None
-    extinction_coefficient: float | None = None
+    bleaching_half_life: Seconds | None = None
+    extinction_coefficient: ExtCoeff | None = None
     quantum_yield: float | None = None
-    lifetime_ns: float | None = None
+    lifetime: Nanoseconds | None = None
 
     @classmethod
     def from_fpbase(cls, name: str) -> "Fluorophore":

--- a/src/microsim/schema/settings.py
+++ b/src/microsim/schema/settings.py
@@ -4,8 +4,9 @@ from typing import ClassVar
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from microsim._field_types import FloatDtype
+
 from ._base_model import SimBaseModel
-from ._field_types import FloatDtype
 from .backend import BackendName, DeviceName, NumpyAPI
 
 

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1,3 +1,4 @@
+import pickle
 from pathlib import Path
 
 import numpy as np
@@ -14,11 +15,6 @@ CONFOCAL_AU0_2 = ms.Confocal(pinhole_au=0.2)
 WIDEFIELD = ms.Widefield()
 
 
-def test_simulation_json_schema() -> None:
-    """Ensure the Simulation model can be cast to JSON schema."""
-    assert isinstance(ms.Simulation.model_json_schema(), dict)
-
-
 @pytest.fixture
 def sim1() -> ms.Simulation:
     return ms.Simulation(
@@ -29,6 +25,17 @@ def sim1() -> ms.Simulation:
         objective_lens=NA1_4,
         channels=[FITC],
     )
+
+
+def test_simulation_json_schema() -> None:
+    """Ensure the Simulation model can be cast to JSON schema."""
+    assert isinstance(ms.Simulation.model_json_schema(), dict)
+
+
+def test_model_dump(sim1: ms.Simulation) -> None:
+    assert isinstance(sim1.model_dump(mode="python"), dict)
+    assert isinstance(sim1.model_dump(mode="json"), dict)
+    assert isinstance(sim1.model_dump_json(), str)
 
 
 @pytest.mark.parametrize("precision", ["f4", "f8"])
@@ -116,3 +123,9 @@ def test_simulation_from_ground_truth() -> None:
     sim = ms.Simulation.from_ground_truth(ground_truth=ground_truth, scale=scale)
     assert sim.truth_space.scale == scale
     np.testing.assert_array_almost_equal(sim.ground_truth(), ground_truth)
+
+
+def test_pickle(sim1: ms.Simulation) -> None:
+    pickled = pickle.dumps(sim1)
+    assert pickle.loads(pickled) == sim1
+    assert sim1.model_copy(deep=True) is not sim1

--- a/x.py
+++ b/x.py
@@ -1,0 +1,43 @@
+from typing import Annotated, Any, Generic, TypeVar
+
+import numpy as np
+import pint
+from pint._typing import UnitLike
+from pint.facets.plain import MagnitudeT, PlainQuantity
+from pydantic import BaseModel, TypeAdapter
+from pydantic.annotated_handlers import GetCoreSchemaHandler
+from pydantic_core import core_schema
+
+T = TypeVar("T", bound=pint.Unit)
+
+
+class Unit(Generic[MagnitudeT]):
+    def __init__(self, unit: UnitLike, mag_type: MagnitudeT | Any = Any) -> None:
+        self.unit = unit
+        self.mag_type = mag_type
+
+    def __get_pydantic_core_schema__(
+        self, source_type: Any, handler: GetCoreSchemaHandler
+    ) -> core_schema.CoreSchema:
+        def _cast_quantity(value: Any) -> PlainQuantity[MagnitudeT]:
+            return pint.Quantity(value, self.unit)
+
+        schema: core_schema.CoreSchema
+        if isinstance(self.mag_type, type) and issubclass(self.mag_type, np.ndarray):
+            schema = core_schema.no_info_before_validator_function(
+                np.asarray,
+                schema=core_schema.list_schema(core_schema.float_schema()),
+            )
+        else:
+            schema = TypeAdapter(self.mag_type).core_schema
+
+        return core_schema.no_info_after_validator_function(
+            _cast_quantity, schema=schema
+        )
+
+
+Meter = Annotated[pint.Quantity, Unit("m")]
+
+
+class Model(BaseModel):
+    meters: Meter


### PR DESCRIPTION
This PR extends `pint.Quantities` to a number of fields, for example, changing:

to 
```python
class State(BaseModel):
    id: int
    exMax: float
    emMax: float
    extCoeff: float
```

```python
class State(BaseModel):
    id: int
    exMax: Nanometers
    emMax: Nanometers
    extCoeff: ExtCoeff
```

where these unit annotations are generally of the form `Annotated[pint.Quantity, some_validator...]`
I think this should aid in readability and help prevent unit-errors in the future, but it may come at the cost of some typing issue (where a dimensionless number is expected but a quantity is provided).  we can continue to re-evaluate