### PR TITLE
fix: fixed typo (from 'placemen' to 'placement')

### DIFF
--- a/src/microsim/schema/optical_config/filter.py
+++ b/src/microsim/schema/optical_config/filter.py
@@ -70,7 +70,7 @@ class _FilterBase(SimBaseModel):
 
         return SpectrumFilter(
             name=filter.ownerFilter.name,
-            placemen=placement,
+            placement=placement,
             transmission=Spectrum.from_fpbase(filter),
         )
 


### PR DESCRIPTION
fix: fixed typo at line 73 of `filter.py`.