### PR TITLE
Fix cosem images download error

### DIFF
--- a/src/microsim/cosem/models.py
+++ b/src/microsim/cosem/models.py
@@ -7,9 +7,9 @@ import urllib.parse
 from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence
 from os import PathLike
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, Annotated
 
-from pydantic import BaseModel, computed_field
+from pydantic import BaseModel, computed_field, AfterValidator
 
 from microsim.util import ndview, norm_name
 
@@ -76,7 +76,7 @@ class CosemImage(BaseModel):
 
     name: str
     description: str
-    url: str
+    url: Annotated[str, AfterValidator(lambda x: x.rstrip("/"))]
     format: ImageFormat
     grid_scale: list[float]
     grid_translation: list[float]

--- a/src/microsim/cosem/models.py
+++ b/src/microsim/cosem/models.py
@@ -7,9 +7,9 @@ import urllib.parse
 from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence
 from os import PathLike
-from typing import TYPE_CHECKING, Any, Literal, Annotated
+from typing import TYPE_CHECKING, Annotated, Any, Literal
 
-from pydantic import BaseModel, computed_field, AfterValidator
+from pydantic import AfterValidator, BaseModel, computed_field
 
 from microsim.util import ndview, norm_name
 


### PR DESCRIPTION
## Description

Some COSEM datasets were not downloadable because of the extra slash in the `CosemImage` class `url` field.

Example: 
```python
dataset = CosemDataset.fetch("jrc_mus-kidney")
segmentation = dataset.image(name="empanada-mito_seg")
segmentation.read(-1)
```

throws an error `IndexError: Level -1 not found in 'empanada-mito_seg'. Available levels: []`
    

## Changes    
Added a validator to the `url` field to strip the extra slash and fix the error. 