### PR TITLE
refactor: remove pint from models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,7 @@ filterwarnings = [
     "error",
     "ignore:unclosed transport:ResourceWarning",             # only on py3.10... not sure why
     "ignore:Clipping negative intensity values:UserWarning", # when importing FPbase spectra
+    "ignore:__array__ implementation doesn't accept a copy keyword"
 ]
 
 # https://coverage.readthedocs.io/en/6.4/config.html

--- a/src/microsim/_field_types.py
+++ b/src/microsim/_field_types.py
@@ -4,7 +4,6 @@ from inspect import signature
 from typing import TYPE_CHECKING, Annotated, Any, Literal, Protocol
 
 import numpy as np
-from pint.facets.plain import PlainQuantity
 from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler, functional_validators
 from pydantic_core import core_schema
 
@@ -147,12 +146,12 @@ NumpyNdarray = Annotated[np.ndarray, _NumpyNdarrayPydanticAnnotation]
 
 # these are all ultimately also numeric and/or array[numeric] types too
 
-Meters = Annotated[PlainQuantity, BeforeValidator(_validators.validate_meters)]
-Microns = Annotated[PlainQuantity, BeforeValidator(_validators.validate_microns)]
-Nanometers = Annotated[PlainQuantity, BeforeValidator(_validators.validate_nm)]
-ExtCoeff = Annotated[PlainQuantity, BeforeValidator(_validators.validate_ext_coeff)]
-Nanoseconds = Annotated[PlainQuantity, BeforeValidator(_validators.validate_ns)]
-Seconds = Annotated[PlainQuantity, BeforeValidator(_validators.validate_seconds)]
+# Meters = Annotated[PlainQuantity, BeforeValidator(_validators.validate_meters)]
+# Microns = Annotated[PlainQuantity, BeforeValidator(_validators.validate_microns)]
+# Nanometers = Annotated[PlainQuantity, BeforeValidator(_validators.validate_nm)]
+# ExtCoeff = Annotated[PlainQuantity, BeforeValidator(_validators.validate_ext_coeff)]
+# Nanoseconds = Annotated[PlainQuantity, BeforeValidator(_validators.validate_ns)]
+# Seconds = Annotated[PlainQuantity, BeforeValidator(_validators.validate_seconds)]
 
-Watts = Annotated[PlainQuantity, BeforeValidator(_validators.validate_watts)]
-Watts_cm2 = Annotated[PlainQuantity, BeforeValidator(_validators.validate_irradiance)]
+# Watts = Annotated[PlainQuantity, BeforeValidator(_validators.validate_watts)]
+# Watts_cm2 = Annotated[PlainQuantity, BeforeValidator(_validators.validate_irradiance)]

--- a/src/microsim/fpbase.py
+++ b/src/microsim/fpbase.py
@@ -6,8 +6,6 @@ from urllib.request import Request, urlopen
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
-from microsim._field_types import ExtCoeff, Nanometers, Nanoseconds
-
 __all__ = ["get_fluorophore", "get_microscope", "FPbaseFluorophore", "FPbaseMicroscope"]
 
 
@@ -42,12 +40,12 @@ class SpectrumOwner(BaseModel):
 
 class State(BaseModel):
     id: int
-    exMax: Nanometers
-    emMax: Nanometers
-    extCoeff: ExtCoeff | None = None
+    exMax: float  # nanometers
+    emMax: float  # nanometers
+    extCoeff: float | None = None  # M^-1 cm^-1
     qy: float | None = None
     spectra: list[Spectrum]
-    lifetime: Nanoseconds | None = None
+    lifetime: float | None = None  # ns
 
     @property
     def excitation_spectrum(self) -> Spectrum | None:

--- a/src/microsim/interval_creation.py
+++ b/src/microsim/interval_creation.py
@@ -118,11 +118,8 @@ def bin_spectrum(
 
     Returns the binned spectrum as a `DataArray`.
     """
-    wavelengths = spectrum.wavelength_nm
-    if isinstance(spectrum.intensity, np.ndarray):
-        intensities = spectrum.intensity
-    else:
-        intensities = spectrum.intensity
+    wavelengths = spectrum.wavelength
+    intensities = spectrum.intensity
     if bins is None:
         bins = generate_bins(
             x=wavelengths, y=intensities, num_bins=num_bins, strategy=binning_strategy

--- a/src/microsim/interval_creation.py
+++ b/src/microsim/interval_creation.py
@@ -118,11 +118,11 @@ def bin_spectrum(
 
     Returns the binned spectrum as a `DataArray`.
     """
-    wavelengths = spectrum.wavelength.magnitude
+    wavelengths = spectrum.wavelength_nm
     if isinstance(spectrum.intensity, np.ndarray):
         intensities = spectrum.intensity
     else:
-        intensities = spectrum.intensity.magnitude
+        intensities = spectrum.intensity
     if bins is None:
         bins = generate_bins(
             x=wavelengths, y=intensities, num_bins=num_bins, strategy=binning_strategy

--- a/src/microsim/psf.py
+++ b/src/microsim/psf.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 import logging
 import os
 from functools import cache
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.typing as npt
 import tqdm
-from pint import Quantity
 
 from microsim.schema.backend import NumpyAPI
 from microsim.schema.lens import ObjectiveKwargs, ObjectiveLens
@@ -351,7 +350,7 @@ def make_psf(
     space: SpaceProtocol,
     channel: OpticalConfig,
     objective: ObjectiveLens,
-    em_wvl: Quantity | None = None,
+    em_wvl_nm: float | None = None,
     pinhole_au: float | None = None,
     max_au_relative: float | None = None,
     xp: NumpyAPI | None = None,
@@ -370,16 +369,16 @@ def make_psf(
     if em is None:
         em = ex
 
-    if em_wvl is None:
-        em_wvl = cast(Quantity, em.center_wave())
+    if em_wvl_nm is None:
+        em_wvl_nm = em.center_wave()
 
     return cached_psf(
         nz=nz,
         nx=nx,
         dx=dx,
         dz=dz,
-        ex_wvl_um=ex.center_wave().to("um").magnitude,
-        em_wvl_um=em_wvl.to("um").magnitude,
+        ex_wvl_um=ex.center_wave() * 1e-3,  # nm to um
+        em_wvl_um=em_wvl_nm * 1e-3,  # nm to um
         objective=_cast_objective(objective),
         pinhole_au=pinhole_au,
         max_au_relative=max_au_relative,

--- a/src/microsim/schema/_emission.py
+++ b/src/microsim/schema/_emission.py
@@ -59,19 +59,20 @@ def get_excitation_rate(
     if not (fluor_ex_spectrum := fluor.excitation_spectrum):
         raise NotImplementedError("Fluorophore has no excitation spectrum.")
 
-    if (ext_coeff := fluor.extinction_coefficient) is None:
-        ext_coeff = _ensure_quantity(55000, "cm^-1/M")
+    if (ec := fluor.extinction_coefficient) is None:
+        ec = 55000
         warnings.warn(
             "No extinction coefficient provided for fluorophore, "
             "using 55,000 M^-1 * cm^-1.",
             stacklevel=2,
         )
 
+    ext_coeff = _ensure_quantity(ec, "cm^-1/M")
     # TODO: derive light power from model
     irradiance = ex_filter_spectrum * _ensure_quantity(light_power, "W/cm^2")
     cross_section = fluor_ex_spectrum * ec_to_cross_section(ext_coeff)
     power_absorbed = cross_section * irradiance
-    excitation_rate = power_absorbed / energy_per_photon(power_absorbed.wavelength)
+    excitation_rate = power_absorbed / energy_per_photon(power_absorbed.wavelength_nm)
     return excitation_rate
 
     # TODO

--- a/src/microsim/schema/_emission.py
+++ b/src/microsim/schema/_emission.py
@@ -72,7 +72,7 @@ def get_excitation_rate(
     irradiance = ex_filter_spectrum * _ensure_quantity(light_power, "W/cm^2")
     cross_section = fluor_ex_spectrum * ec_to_cross_section(ext_coeff)
     power_absorbed = cross_section * irradiance
-    excitation_rate = power_absorbed / energy_per_photon(power_absorbed.wavelength_nm)
+    excitation_rate = power_absorbed / energy_per_photon(power_absorbed.wavelength)
     return excitation_rate
 
     # TODO

--- a/src/microsim/schema/lens.py
+++ b/src/microsim/schema/lens.py
@@ -3,8 +3,6 @@ from typing import Any, TypedDict
 import numpy as np
 from pydantic import Field, model_validator
 
-from microsim._field_types import Microns
-
 from ._base_model import SimBaseModel
 
 
@@ -28,12 +26,9 @@ class ObjectiveLens(SimBaseModel):
     immersion_medium_ri: float = 1.515  # immersion medium RI experimental value (ni)
     immersion_medium_ri_spec: float = 1.515  # immersion medium RI design value (ni0)
     specimen_ri: float = 1.47  # specimen refractive index (ns)
-    # um, working distance, design value (ti0)
-    working_distance: Microns = 150.0  # type: ignore
-    # um, coverslip thickness (tg)
-    coverslip_thickness: Microns = 170.0  # type: ignore
-    # um, coverslip thickness design (tg0)
-    coverslip_thickness_spec: Microns = 170.0  # type: ignore
+    working_distance_um: float = 150.0  # um, working distance, design value (ti0)
+    coverslip_thickness_um: float = 170.0  # um, coverslip thickness (tg)
+    coverslip_thickness_spec_um: float = 170.0  # um, coverslip thickness design (tg0)
 
     magnification: float = Field(1, description="magnification of objective lens.")
 
@@ -54,9 +49,9 @@ class ObjectiveLens(SimBaseModel):
                 self.immersion_medium_ri,
                 self.immersion_medium_ri_spec,
                 self.specimen_ri,
-                self.working_distance,
-                self.coverslip_thickness,
-                self.coverslip_thickness_spec,
+                self.working_distance_um,
+                self.coverslip_thickness_um,
+                self.coverslip_thickness_spec_um,
                 self.magnification,
             )
         )
@@ -91,15 +86,15 @@ class ObjectiveLens(SimBaseModel):
 
     @property
     def tg(self) -> float:
-        return float(self.coverslip_thickness.to("meters").magnitude)
+        return self.coverslip_thickness_um * 1e-6  # convert to meters
 
     @property
     def tg0(self) -> float:
-        return float(self.coverslip_thickness_spec.to("meters").magnitude)
+        return self.coverslip_thickness_spec_um * 1e-6  # convert to meters
 
     @property
     def ti0(self) -> float:
-        return float(self.working_distance.to("meters").magnitude)
+        return self.working_distance_um * 1e-6  # convert to meters
 
     @property
     def ng0(self) -> float:

--- a/src/microsim/schema/optical_config/config.py
+++ b/src/microsim/schema/optical_config/config.py
@@ -4,7 +4,6 @@ from typing import Any
 
 from pydantic import Field, model_validator
 
-from microsim._field_types import Watts, Watts_cm2
 from microsim.fpbase import SpectrumOwner
 from microsim.schema._base_model import SimBaseModel
 from microsim.schema.spectrum import Spectrum
@@ -15,7 +14,7 @@ from .filter import Filter, Placement, SpectrumFilter
 class LightSource(SimBaseModel):
     name: str = ""
     spectrum: Spectrum
-    power: Watts | Watts_cm2 | None = None
+    power: float | None = None  # W/cm^2
 
     @classmethod
     def from_fpbase(cls, light: SpectrumOwner) -> "LightSource":
@@ -135,7 +134,7 @@ class OpticalConfig(SimBaseModel):
 
         legend = []
         for filt in self.filters:
-            ax.plot(filt.spectrum.wavelength.magnitude, filt.spectrum.intensity)
+            ax.plot(filt.spectrum.wavelength_nm, filt.spectrum.intensity)
             legend.append(filt.name)
         if any(legend):
             ax.legend(legend)

--- a/src/microsim/schema/optical_config/config.py
+++ b/src/microsim/schema/optical_config/config.py
@@ -134,7 +134,7 @@ class OpticalConfig(SimBaseModel):
 
         legend = []
         for filt in self.filters:
-            ax.plot(filt.spectrum.wavelength_nm, filt.spectrum.intensity)
+            ax.plot(filt.spectrum.wavelength, filt.spectrum.intensity)
             legend.append(filt.name)
         if any(legend):
             ax.legend(legend)

--- a/src/microsim/schema/optical_config/lib.py
+++ b/src/microsim/schema/optical_config/lib.py
@@ -5,9 +5,9 @@ from microsim.schema.optical_config.filter import Bandpass, Longpass
 DAPI = OpticalConfig(
     name="DAPI",
     filters=[
-        Bandpass(bandcenter=350, bandwidth=50, placement="EX"),
-        Longpass(cuton=400, placement="BS"),
-        Bandpass(bandcenter=460, bandwidth=50, placement="EM"),
+        Bandpass(bandcenter_nm=350, bandwidth_nm=50, placement="EX"),
+        Longpass(cuton_nm=400, placement="BS"),
+        Bandpass(bandcenter_nm=460, bandwidth_nm=50, placement="EM"),
     ],
 )
 
@@ -15,9 +15,9 @@ DAPI = OpticalConfig(
 ECFP = OpticalConfig(
     name="ECFP",
     filters=[
-        Bandpass(bandcenter=436, bandwidth=20, placement="EX"),
-        Longpass(cuton=455, placement="BS"),
-        Bandpass(bandcenter=480, bandwidth=40, placement="EM"),
+        Bandpass(bandcenter_nm=436, bandwidth_nm=20, placement="EX"),
+        Longpass(cuton_nm=455, placement="BS"),
+        Bandpass(bandcenter_nm=480, bandwidth_nm=40, placement="EM"),
     ],
 )
 
@@ -25,9 +25,9 @@ ECFP = OpticalConfig(
 FITC = OpticalConfig(
     name="FITC",
     filters=[
-        Bandpass(bandcenter=470, bandwidth=40, placement="EX"),
-        Longpass(cuton=495, placement="BS"),
-        Bandpass(bandcenter=525, bandwidth=50, placement="EM"),
+        Bandpass(bandcenter_nm=470, bandwidth_nm=40, placement="EX"),
+        Longpass(cuton_nm=495, placement="BS"),
+        Bandpass(bandcenter_nm=525, bandwidth_nm=50, placement="EM"),
     ],
 )
 
@@ -35,9 +35,9 @@ FITC = OpticalConfig(
 EYFP = OpticalConfig(
     name="EYFP",
     filters=[
-        Bandpass(bandcenter=500, bandwidth=20, placement="EX"),
-        Longpass(cuton=515, placement="BS"),
-        Bandpass(bandcenter=535, bandwidth=30, placement="EM"),
+        Bandpass(bandcenter_nm=500, bandwidth_nm=20, placement="EX"),
+        Longpass(cuton_nm=515, placement="BS"),
+        Bandpass(bandcenter_nm=535, bandwidth_nm=30, placement="EM"),
     ],
 )
 
@@ -45,9 +45,9 @@ EYFP = OpticalConfig(
 TRITC = OpticalConfig(
     name="TRITC",
     filters=[
-        Bandpass(bandcenter=545, bandwidth=25, placement="EX"),
-        Longpass(cuton=565, placement="BS"),
-        Bandpass(bandcenter=605, bandwidth=70, placement="EM"),
+        Bandpass(bandcenter_nm=545, bandwidth_nm=25, placement="EX"),
+        Longpass(cuton_nm=565, placement="BS"),
+        Bandpass(bandcenter_nm=605, bandwidth_nm=70, placement="EM"),
     ],
 )
 
@@ -55,9 +55,9 @@ TRITC = OpticalConfig(
 DSRED = OpticalConfig(
     name="DSRED",
     filters=[
-        Bandpass(bandcenter=545, bandwidth=30, placement="EX"),
-        Longpass(cuton=570, placement="BS"),
-        Bandpass(bandcenter=620, bandwidth=60, placement="EM"),
+        Bandpass(bandcenter_nm=545, bandwidth_nm=30, placement="EX"),
+        Longpass(cuton_nm=570, placement="BS"),
+        Bandpass(bandcenter_nm=620, bandwidth_nm=60, placement="EM"),
     ],
 )
 
@@ -65,9 +65,9 @@ DSRED = OpticalConfig(
 CY5 = OpticalConfig(
     name="CY5",
     filters=[
-        Bandpass(bandcenter=620, bandwidth=60, placement="EX"),
-        Longpass(cuton=660, placement="BS"),
-        Bandpass(bandcenter=700, bandwidth=75, placement="EM"),
+        Bandpass(bandcenter_nm=620, bandwidth_nm=60, placement="EX"),
+        Longpass(cuton_nm=660, placement="BS"),
+        Bandpass(bandcenter_nm=700, bandwidth_nm=75, placement="EM"),
     ],
 )
 
@@ -75,8 +75,8 @@ CY5 = OpticalConfig(
 CY7 = OpticalConfig(
     name="CY7",
     filters=[
-        Bandpass(bandcenter=710, bandwidth=75, placement="EX"),
-        Longpass(cuton=760, placement="BS"),
-        Bandpass(bandcenter=810, bandwidth=90, placement="EM"),
+        Bandpass(bandcenter_nm=710, bandwidth_nm=75, placement="EX"),
+        Longpass(cuton_nm=760, placement="BS"),
+        Bandpass(bandcenter_nm=810, bandwidth_nm=90, placement="EM"),
     ],
 )

--- a/src/microsim/schema/optical_config/lib.py
+++ b/src/microsim/schema/optical_config/lib.py
@@ -5,9 +5,9 @@ from microsim.schema.optical_config.filter import Bandpass, Longpass
 DAPI = OpticalConfig(
     name="DAPI",
     filters=[
-        Bandpass(bandcenter_nm=350, bandwidth_nm=50, placement="EX"),
-        Longpass(cuton_nm=400, placement="BS"),
-        Bandpass(bandcenter_nm=460, bandwidth_nm=50, placement="EM"),
+        Bandpass(bandcenter=350, bandwidth=50, placement="EX"),
+        Longpass(cuton=400, placement="BS"),
+        Bandpass(bandcenter=460, bandwidth=50, placement="EM"),
     ],
 )
 
@@ -15,9 +15,9 @@ DAPI = OpticalConfig(
 ECFP = OpticalConfig(
     name="ECFP",
     filters=[
-        Bandpass(bandcenter_nm=436, bandwidth_nm=20, placement="EX"),
-        Longpass(cuton_nm=455, placement="BS"),
-        Bandpass(bandcenter_nm=480, bandwidth_nm=40, placement="EM"),
+        Bandpass(bandcenter=436, bandwidth=20, placement="EX"),
+        Longpass(cuton=455, placement="BS"),
+        Bandpass(bandcenter=480, bandwidth=40, placement="EM"),
     ],
 )
 
@@ -25,9 +25,9 @@ ECFP = OpticalConfig(
 FITC = OpticalConfig(
     name="FITC",
     filters=[
-        Bandpass(bandcenter_nm=470, bandwidth_nm=40, placement="EX"),
-        Longpass(cuton_nm=495, placement="BS"),
-        Bandpass(bandcenter_nm=525, bandwidth_nm=50, placement="EM"),
+        Bandpass(bandcenter=470, bandwidth=40, placement="EX"),
+        Longpass(cuton=495, placement="BS"),
+        Bandpass(bandcenter=525, bandwidth=50, placement="EM"),
     ],
 )
 
@@ -35,9 +35,9 @@ FITC = OpticalConfig(
 EYFP = OpticalConfig(
     name="EYFP",
     filters=[
-        Bandpass(bandcenter_nm=500, bandwidth_nm=20, placement="EX"),
-        Longpass(cuton_nm=515, placement="BS"),
-        Bandpass(bandcenter_nm=535, bandwidth_nm=30, placement="EM"),
+        Bandpass(bandcenter=500, bandwidth=20, placement="EX"),
+        Longpass(cuton=515, placement="BS"),
+        Bandpass(bandcenter=535, bandwidth=30, placement="EM"),
     ],
 )
 
@@ -45,9 +45,9 @@ EYFP = OpticalConfig(
 TRITC = OpticalConfig(
     name="TRITC",
     filters=[
-        Bandpass(bandcenter_nm=545, bandwidth_nm=25, placement="EX"),
-        Longpass(cuton_nm=565, placement="BS"),
-        Bandpass(bandcenter_nm=605, bandwidth_nm=70, placement="EM"),
+        Bandpass(bandcenter=545, bandwidth=25, placement="EX"),
+        Longpass(cuton=565, placement="BS"),
+        Bandpass(bandcenter=605, bandwidth=70, placement="EM"),
     ],
 )
 
@@ -55,9 +55,9 @@ TRITC = OpticalConfig(
 DSRED = OpticalConfig(
     name="DSRED",
     filters=[
-        Bandpass(bandcenter_nm=545, bandwidth_nm=30, placement="EX"),
-        Longpass(cuton_nm=570, placement="BS"),
-        Bandpass(bandcenter_nm=620, bandwidth_nm=60, placement="EM"),
+        Bandpass(bandcenter=545, bandwidth=30, placement="EX"),
+        Longpass(cuton=570, placement="BS"),
+        Bandpass(bandcenter=620, bandwidth=60, placement="EM"),
     ],
 )
 
@@ -65,9 +65,9 @@ DSRED = OpticalConfig(
 CY5 = OpticalConfig(
     name="CY5",
     filters=[
-        Bandpass(bandcenter_nm=620, bandwidth_nm=60, placement="EX"),
-        Longpass(cuton_nm=660, placement="BS"),
-        Bandpass(bandcenter_nm=700, bandwidth_nm=75, placement="EM"),
+        Bandpass(bandcenter=620, bandwidth=60, placement="EX"),
+        Longpass(cuton=660, placement="BS"),
+        Bandpass(bandcenter=700, bandwidth=75, placement="EM"),
     ],
 )
 
@@ -75,8 +75,8 @@ CY5 = OpticalConfig(
 CY7 = OpticalConfig(
     name="CY7",
     filters=[
-        Bandpass(bandcenter_nm=710, bandwidth_nm=75, placement="EX"),
-        Longpass(cuton_nm=760, placement="BS"),
-        Bandpass(bandcenter_nm=810, bandwidth_nm=90, placement="EM"),
+        Bandpass(bandcenter=710, bandwidth=75, placement="EX"),
+        Longpass(cuton=760, placement="BS"),
+        Bandpass(bandcenter=810, bandwidth=90, placement="EM"),
     ],
 )

--- a/src/microsim/schema/sample/fluorophore.py
+++ b/src/microsim/schema/sample/fluorophore.py
@@ -49,11 +49,11 @@ class Fluorophore(SimBaseModel):
 
         fig, ax = plt.subplots(figsize=(12, 3))
         ax.plot(
-            self.excitation_spectrum.wavelength_nm,
+            self.excitation_spectrum.wavelength,
             self.excitation_spectrum.intensity,
         )
         ax.plot(
-            self.emission_spectrum.wavelength_nm,
+            self.emission_spectrum.wavelength,
             self.emission_spectrum.intensity,
         )
         ax.set_xlabel("Wavelength (nm)")

--- a/src/microsim/schema/sample/fluorophore.py
+++ b/src/microsim/schema/sample/fluorophore.py
@@ -2,7 +2,6 @@ from typing import Any
 
 from pydantic import model_validator
 
-from microsim._field_types import ExtCoeff, Nanoseconds, Seconds
 from microsim.schema._base_model import SimBaseModel
 from microsim.schema.spectrum import Spectrum
 
@@ -11,10 +10,10 @@ class Fluorophore(SimBaseModel):
     name: str
     excitation_spectrum: Spectrum
     emission_spectrum: Spectrum
-    bleaching_half_life: Seconds | None = None
-    extinction_coefficient: ExtCoeff | None = None
+    bleaching_half_life_s: float | None = None
+    extinction_coefficient: float | None = None  # M^-1 cm^-1
     quantum_yield: float | None = None
-    lifetime: Nanoseconds | None = None
+    lifetime_ns: float | None = None
 
     @classmethod
     def from_fpbase(cls, name: str) -> "Fluorophore":
@@ -50,11 +49,11 @@ class Fluorophore(SimBaseModel):
 
         fig, ax = plt.subplots(figsize=(12, 3))
         ax.plot(
-            self.excitation_spectrum.wavelength.magnitude,
+            self.excitation_spectrum.wavelength_nm,
             self.excitation_spectrum.intensity,
         )
         ax.plot(
-            self.emission_spectrum.wavelength.magnitude,
+            self.emission_spectrum.wavelength_nm,
             self.emission_spectrum.intensity,
         )
         ax.set_xlabel("Wavelength (nm)")

--- a/src/microsim/schema/simulation.py
+++ b/src/microsim/schema/simulation.py
@@ -200,7 +200,7 @@ class Simulation(SimBaseModel):
             raise ValueError("No fluorophores in the current sample!")
 
         # Get emission spectra for all the fluorophores
-        fluor_em_spectra = []
+        fluor_em_spectra: list[np.ndarray] = []
         for fluor in fluorophores:
             if fluor is None:
                 fluor_em_spectra.append(
@@ -210,7 +210,7 @@ class Simulation(SimBaseModel):
                 )
             else:
                 # get emission Spectrum for the given fluorophore
-                fluor_em_spectra.append(fluor.emission_spectrum.wavelength.magnitude)
+                fluor_em_spectra.append(fluor.emission_spectrum.wavelength_nm)
 
         # Get the min and max wavelength over all the spectra
         min_wave = min([x.min() for x in fluor_em_spectra])
@@ -251,7 +251,7 @@ class Simulation(SimBaseModel):
         if not illum:
             # If illumination is not defined, we assume a white light source
             illum = Spectrum(
-                wavelength=np.arange(
+                wavelength_nm=np.arange(
                     self.settings.min_wavelength, self.settings.max_wavelength, 1
                 ),
                 intensity=np.ones(

--- a/src/microsim/schema/simulation.py
+++ b/src/microsim/schema/simulation.py
@@ -210,7 +210,7 @@ class Simulation(SimBaseModel):
                 )
             else:
                 # get emission Spectrum for the given fluorophore
-                fluor_em_spectra.append(fluor.emission_spectrum.wavelength_nm)
+                fluor_em_spectra.append(fluor.emission_spectrum.wavelength)
 
         # Get the min and max wavelength over all the spectra
         min_wave = min([x.min() for x in fluor_em_spectra])
@@ -251,7 +251,7 @@ class Simulation(SimBaseModel):
         if not illum:
             # If illumination is not defined, we assume a white light source
             illum = Spectrum(
-                wavelength_nm=np.arange(
+                wavelength=np.arange(
                     self.settings.min_wavelength, self.settings.max_wavelength, 1
                 ),
                 intensity=np.ones(


### PR DESCRIPTION
this PR effectively undoes #37 and closes #70

while I love the concept of using pint to ensure that quantities and units are handled correctly, it does get annoying to deal with non built-in types throughout the pipeline, where it's not always clear whether you're getting a quantity (which requires special `.magnitude` handling in some cases).  Leading to stuff like #70

I'm not dropping the dependency on pint yet, so it's still possible to use pint in functions calculating difficult stuff, like fluorophore photon emissions, for example, but there we would simply cast to/from quantities while doing the calculations, but not use them for model fields directly