### PR TITLE
feat: adding Identity PSF modality

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,13 +10,13 @@ repos:
       - id: validate-pyproject
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.24.1
+    rev: v1.24.5
     hooks:
       - id: typos
         args: [--force-exclude]  # omitting --write-changes
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.2
+    rev: v0.6.4
     hooks:
       - id: ruff
         args: [--fix, --unsafe-fixes]

--- a/src/microsim/schema/__init__.py
+++ b/src/microsim/schema/__init__.py
@@ -3,7 +3,7 @@ import logging
 from .backend import BackendName, DeviceName, NumpyAPI
 from .detectors import Camera, CameraCCD, CameraCMOS, CameraEMCCD
 from .lens import ObjectiveLens
-from .modality import Confocal, Modality, Widefield
+from .modality import Confocal, Modality, Widefield, Identity
 from .optical_config import (
     Bandpass,
     LightSource,
@@ -33,6 +33,7 @@ __all__ = [
     "ExtentScaleSpace",
     "Fluorophore",
     "FluorophoreDistribution",
+    "Identity",
     "SpectrumFilter",
     "Longpass",
     "MatsLines",

--- a/src/microsim/schema/__init__.py
+++ b/src/microsim/schema/__init__.py
@@ -3,7 +3,7 @@ import logging
 from .backend import BackendName, DeviceName, NumpyAPI
 from .detectors import Camera, CameraCCD, CameraCMOS, CameraEMCCD
 from .lens import ObjectiveLens
-from .modality import Confocal, Modality, Widefield, Identity
+from .modality import Confocal, Identity, Modality, Widefield
 from .optical_config import (
     Bandpass,
     LightSource,

--- a/src/microsim/schema/modality/__init__.py
+++ b/src/microsim/schema/modality/__init__.py
@@ -1,4 +1,4 @@
-from ._simple import Confocal, Widefield, Identity
+from ._simple import Confocal, Identity, Widefield
 
 Modality = Confocal | Widefield | Identity
 

--- a/src/microsim/schema/modality/__init__.py
+++ b/src/microsim/schema/modality/__init__.py
@@ -1,5 +1,5 @@
-from ._simple import Confocal, Widefield
+from ._simple import Confocal, Widefield, Identity
 
-Modality = Confocal | Widefield
+Modality = Confocal | Widefield | Identity
 
-__all__ = ["Modality", "Confocal", "Widefield"]
+__all__ = ["Identity", "Modality", "Confocal", "Widefield"]

--- a/src/microsim/schema/modality/_simple.py
+++ b/src/microsim/schema/modality/_simple.py
@@ -191,9 +191,11 @@ class Widefield(_PSFModality):
 class Identity(_PSFModality):
     """Optical modality in which PSF is not applied.
 
-    The idea is to use this modality when the ground truth flurophore
-    distribution is generated from a light micorscope image, i.e., the
-    PSF convolution is already applied on the image.
+    The idea is to use this modality when the ground truth flurophore distribution is
+    generated from a light micorscope image, i.e., the PSF convolution is already
+    applied on the image.  This is useful primarily when you are more interested in the
+    spectral properties (fluorophores, filters, bleedthrough, etc.) than the spatial
+    properties (PSF, modality, etc.) in the simulation.
     """
 
     def render(
@@ -205,9 +207,9 @@ class Identity(_PSFModality):
     ) -> xrDataArray:
         """Render a 3D image of the truth for F fluorophores, in C channels.
 
-        In this case we don't apply the PSF convolution, as the truth is assumed
-        to be already convolved with the PSF. Therefore, we simply compute the
-        emission flux for each fluorophore and each channel.
+        In this case we don't apply the PSF convolution, as the truth is assumed to be
+        already convolved with the PSF. Therefore, we simply compute the emission flux
+        for each fluorophore and each channel.
         """
         em_image = em_rates.sum(Axis.W) * truth
         return DataArray(

--- a/src/microsim/schema/modality/_simple.py
+++ b/src/microsim/schema/modality/_simple.py
@@ -186,6 +186,29 @@ class Confocal(_PSFModality):
 
 class Widefield(_PSFModality):
     type: Literal["widefield"] = "widefield"
+    
+
+class Identity(_PSFModality):
+    """Optical modality in which PSF is not applied.
+    
+    The idea is to use this modality when the ground truth flurophore 
+    distribution is generated from a light micorscope image, i.e., the 
+    PSF convolution is already applied on the image.
+    """
+    
+    def psf(
+        self,
+        *,
+        nz: int,
+        nx: int,
+        dx: float,
+        dz: float,
+        objective_lens: ObjectiveLens,
+        xp: NumpyAPI,
+        ex_wvl_nm: float | None = None,
+        em_wvl_nm: float | None = None,
+    ) -> ArrayProtocol:
+        return xp.ones((nz, nx, nx))
 
 
 def bin_spectrum(

--- a/src/microsim/schema/modality/_simple.py
+++ b/src/microsim/schema/modality/_simple.py
@@ -186,16 +186,16 @@ class Confocal(_PSFModality):
 
 class Widefield(_PSFModality):
     type: Literal["widefield"] = "widefield"
-    
+
 
 class Identity(_PSFModality):
     """Optical modality in which PSF is not applied.
-    
-    The idea is to use this modality when the ground truth flurophore 
-    distribution is generated from a light micorscope image, i.e., the 
+
+    The idea is to use this modality when the ground truth flurophore
+    distribution is generated from a light micorscope image, i.e., the
     PSF convolution is already applied on the image.
     """
-    
+
     def render(
         self,
         truth: xrDataArray,  # (F, Z, Y, X)
@@ -204,9 +204,9 @@ class Identity(_PSFModality):
         **kwargs: Any,
     ) -> xrDataArray:
         """Render a 3D image of the truth for F fluorophores, in C channels.
-        
+
         In this case we don't apply the PSF convolution, as the truth is assumed
-        to be already convolved with the PSF. Therefore, we simply compute the 
+        to be already convolved with the PSF. Therefore, we simply compute the
         emission flux for each fluorophore and each channel.
         """
         em_image = em_rates.sum(Axis.W) * truth


### PR DESCRIPTION
Added `Identity` as a new `_PSFModality`.

- **What**: this new modality skips PSF convolution. Hence, the optical image corresponds to the so-called "*emission flux*".
- **How**: by overriding the `render()` method of `_PSFModality`. Now it simply multiplies the GT array by the emission spectra for the different channels and FPs.
- **Why**: we need this modality in the case the ground truth (FP distrib) is obtained from a light microscopy image (i.e., already convolved by the PSF). For instance, we can have this situation when we want to simulate a spectral image staring from a single frame.

 