### PR TITLE
feat: scaling each light source by the respective power

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,13 +10,13 @@ repos:
       - id: validate-pyproject
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.24.1
+    rev: v1.24.5
     hooks:
       - id: typos
         args: [--force-exclude]  # omitting --write-changes
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.2
+    rev: v0.6.4
     hooks:
       - id: ruff
         args: [--fix, --unsafe-fixes]

--- a/src/microsim/schema/optical_config/config.py
+++ b/src/microsim/schema/optical_config/config.py
@@ -154,10 +154,11 @@ class OpticalConfig(SimBaseModel):
         exc = self.excitation
         if self.lights:
             l0, *rest = self.lights
-            illum_spect = l0.spectrum
+            p0, *p_rest = [l.power or 1 for l in self.lights] 
+            illum_spect = l0.spectrum * p0
             if rest:
-                for light in rest:
-                    illum_spect = illum_spect + light.spectrum
+                for light, power in zip(rest, p_rest):
+                    illum_spect = illum_spect + light.spectrum * power
             if exc:
                 return illum_spect * exc.spectrum
             return illum_spect

--- a/src/microsim/schema/optical_config/config.py
+++ b/src/microsim/schema/optical_config/config.py
@@ -162,7 +162,11 @@ class OpticalConfig(SimBaseModel):
         """
         exc = self.excitation
         if self.lights:
-            illum_spect = sum(light.scaled_spectrum() for light in self.lights)
+            l0, *rest = self.lights
+            illum_spect = l0.scaled_spectrum()
+            if rest:
+                for light in rest:
+                    illum_spect = illum_spect + light.scaled_spectrum()
             if exc:
                 return illum_spect * exc.spectrum
             return illum_spect

--- a/src/microsim/schema/optical_config/config.py
+++ b/src/microsim/schema/optical_config/config.py
@@ -41,6 +41,13 @@ class LightSource(SimBaseModel):
             ),
             power=power,
         )
+        
+    def scaled_spectrum(self) -> Spectrum:
+        """Return light source spectrum scaled to power, if present."""
+        spectrum = self.spectrum
+        if self.power is not None:
+            spectrum = spectrum * self.power
+        return spectrum
 
 
 class OpticalConfig(SimBaseModel):
@@ -155,12 +162,7 @@ class OpticalConfig(SimBaseModel):
         """
         exc = self.excitation
         if self.lights:
-            l0, *rest = self.lights
-            p0, *p_rest = (l.power or 1 for l in self.lights)
-            illum_spect = l0.spectrum * p0
-            if rest:
-                for light, power in zip(rest, p_rest, strict=False):
-                    illum_spect = illum_spect + light.spectrum * power
+            illum_spect = sum(light.scaled_spectrum() for light in self.lights)
             if exc:
                 return illum_spect * exc.spectrum
             return illum_spect

--- a/src/microsim/schema/optical_config/config.py
+++ b/src/microsim/schema/optical_config/config.py
@@ -156,10 +156,10 @@ class OpticalConfig(SimBaseModel):
         exc = self.excitation
         if self.lights:
             l0, *rest = self.lights
-            p0, *p_rest = [l.power or 1 for l in self.lights] 
+            p0, *p_rest = (l.power or 1 for l in self.lights)
             illum_spect = l0.spectrum * p0
             if rest:
-                for light, power in zip(rest, p_rest):
+                for light, power in zip(rest, p_rest, strict=False):
                     illum_spect = illum_spect + light.spectrum * power
             if exc:
                 return illum_spect * exc.spectrum

--- a/src/microsim/schema/optical_config/config.py
+++ b/src/microsim/schema/optical_config/config.py
@@ -150,6 +150,8 @@ class OpticalConfig(SimBaseModel):
 
         This represents the spectrum of light source and all of the filters in the
         excitation path. If there are multiple light sources, they are combined.
+        Different light sources can have different powers. In that case light sources
+        are scaled by the respective light powers.
         """
         exc = self.excitation
         if self.lights:


### PR DESCRIPTION
- **What**: This PR is meant to allow the user to scale each `LightSource` spectrum by the respective `power` attribute during the combination of different light sources while computing the `illumination` property of `OpticalConfig` class. If the `power` attribute of a light source is not defined, then nothing happens.
- **Why**:  this feature allows the user to combine light sources with different powers within the same `OpticalConfig` (i.e., need only one channel, hence reducing the computation cost). For instance, this can be desirable when the light source is a composition of different laser beams each one targeting a different fluorophore. In this case, the user may want to excite different FPs with different powers (e.g., because they have different quantum yields or cross sections). 
- **How**: in `illumination` property, light sources' spectra are scaled by the correspondent power before combining them. 

*NOTE*: Such powers should be regarded as scaling factors, rather than true physical powers. Indeed, after the `illumination` is defined, in the `irradiance` property computation, the resulting signal gets normalized. Therefore, the absolute value of the illumination is suppressed, while the relative importance of different light sources is retained.