### PR TITLE
allow any object with render method to be used for label distribution

### DIFF
--- a/src/microsim/schema/sample/__init__.py
+++ b/src/microsim/schema/sample/__init__.py
@@ -1,13 +1,15 @@
+from ._distributions._base import BaseDistribution
 from ._distributions.cosem import CosemLabel
 from ._distributions.matslines import MatsLines
 from .fluorophore import Fluorophore
 from .sample import AnyDistribution, FluorophoreDistribution, Sample
 
 __all__ = [
+    "AnyDistribution",
+    "BaseDistribution",
+    "CosemLabel",
+    "Fluorophore",
+    "FluorophoreDistribution",
     "MatsLines",
     "Sample",
-    "CosemLabel",
-    "AnyDistribution",
-    "FluorophoreDistribution",
-    "Fluorophore",
 ]

--- a/src/microsim/schema/sample/__init__.py
+++ b/src/microsim/schema/sample/__init__.py
@@ -1,13 +1,13 @@
 from ._distributions.cosem import CosemLabel
 from ._distributions.matslines import MatsLines
 from .fluorophore import Fluorophore
-from .sample import Distribution, FluorophoreDistribution, Sample
+from .sample import AnyDistribution, FluorophoreDistribution, Sample
 
 __all__ = [
     "MatsLines",
     "Sample",
     "CosemLabel",
-    "Distribution",
+    "AnyDistribution",
     "FluorophoreDistribution",
     "Fluorophore",
 ]

--- a/src/microsim/schema/sample/_distributions/_base.py
+++ b/src/microsim/schema/sample/_distributions/_base.py
@@ -1,13 +1,40 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Annotated, Any, Protocol
 
-from pydantic import BaseModel
+from pydantic import BaseModel, GetCoreSchemaHandler
+from pydantic_core import core_schema
+from typing_extensions import runtime_checkable
 
 if TYPE_CHECKING:
     from microsim._data_array import xrDataArray
     from microsim.schema.backend import NumpyAPI
+
+
+@runtime_checkable
+class Renderable(Protocol):
+    @abstractmethod
+    def render(self, space: xrDataArray, xp: NumpyAPI | None = None) -> xrDataArray:
+        """Render the distribution into the given space."""
+
+
+class _IsInstanceAnySer:
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, source_type: Any, handler: GetCoreSchemaHandler
+    ) -> core_schema.CoreSchema:
+        def _validate(obj: Any) -> Any:
+            if not isinstance(obj, source_type):
+                raise ValueError(f"Expected {source_type}, got {type(obj)}")
+            return obj
+
+        return core_schema.no_info_before_validator_function(
+            _validate, core_schema.any_schema()
+        )
+
+
+RenderableType = Annotated[Renderable, _IsInstanceAnySer()]
 
 
 class _BaseDistribution(BaseModel, ABC):

--- a/src/microsim/schema/sample/_distributions/_base.py
+++ b/src/microsim/schema/sample/_distributions/_base.py
@@ -37,7 +37,7 @@ class _IsInstanceAnySer:
 RenderableType = Annotated[Renderable, _IsInstanceAnySer()]
 
 
-class _BaseDistribution(BaseModel, ABC):
+class BaseDistribution(BaseModel, ABC):
     @classmethod
     def is_random(cls) -> bool:
         """Return True if this distribution generates randomized results."""

--- a/src/microsim/schema/sample/_distributions/cosem.py
+++ b/src/microsim/schema/sample/_distributions/cosem.py
@@ -7,7 +7,7 @@ from pydantic import BeforeValidator, computed_field, model_validator
 from microsim.cosem.models import CosemDataset, CosemImage
 from microsim.schema.backend import NumpyAPI
 
-from ._base import _BaseDistribution
+from ._base import BaseDistribution
 
 if TYPE_CHECKING:
     from microsim._data_array import xrDataArray
@@ -25,7 +25,7 @@ def _validate_dataset(v: Any) -> CosemDataset:
 Dataset = Annotated[CosemDataset, BeforeValidator(_validate_dataset)]
 
 
-class CosemLabel(_BaseDistribution):
+class CosemLabel(BaseDistribution):
     """Renders ground truth based on a specific layer from a COSEM dataset.
 
     Go to https://openorganelle.janelia.org/datasets/ to find a dataset, and then

--- a/src/microsim/schema/sample/_distributions/direct.py
+++ b/src/microsim/schema/sample/_distributions/direct.py
@@ -4,13 +4,13 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from microsim.schema.backend import NumpyAPI
 
-from ._base import _BaseDistribution
+from ._base import BaseDistribution
 
 if TYPE_CHECKING:
     from microsim._data_array import xrDataArray
 
 
-class FixedArrayTruth(_BaseDistribution):
+class FixedArrayTruth(BaseDistribution):
     type: Literal["fixed-array"] = "fixed-array"
     array: Any
 

--- a/src/microsim/schema/sample/_distributions/matslines.py
+++ b/src/microsim/schema/sample/_distributions/matslines.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Literal
 import numpy as np
 
 from microsim.schema.backend import NumpyAPI
-from microsim.schema.sample._distributions._base import _BaseDistribution
+from microsim.schema.sample._distributions._base import BaseDistribution
 
 if TYPE_CHECKING:
     import numpy.typing as npt
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from microsim._data_array import xrDataArray
 
 
-class MatsLines(_BaseDistribution):
+class MatsLines(BaseDistribution):
     type: Literal["matslines"] = "matslines"
     density: float = 1
     length: int = 10

--- a/src/microsim/schema/simulation.py
+++ b/src/microsim/schema/simulation.py
@@ -307,7 +307,7 @@ class Simulation(SimBaseModel):
         scale = f'scale{"_".join(str(x) for x in truth_space.scale)}'
         conc = f"conc{label.concentration}"
         truth_cache = truth_cache / shape / scale / conc
-        if label.distribution.is_random():
+        if hasattr(label.distribution, "is_random") and label.distribution.is_random():
             truth_cache = truth_cache / f"seed{seed}"
         return truth_cache
 


### PR DESCRIPTION
fixes #82 

this lets *any* object that implements a `render()` method be used as a fluorophore distribution object (via duck typing).  which should make things like @melisande-c's kymograph generation easier to use without using `from_ground_truth`

```python
class MyCustomDistribution:
    def render(self, space, xp: ms.NumpyAPI | None = None):
        # ...
        return space

sim = ms.Simulation(
    truth_space=ms.ShapeScaleSpace(shape=(64, 128, 128), scale=(0.2, 0.1, 0.1)),
    output_space={"downscale": 1},
    sample=ms.Sample(labels=[MyCustomDistribution()]),
)
```

it also exposes `BaseDistribution` publicly ... so if you prefer to subclass (rather than rely on Protocols and duck-typing) then you can.

@melisande-c, let me know if this would help out in your case

