### PR TITLE
fix: restrict intensity to positive values after read-noise application

### DIFF
--- a/src/microsim/schema/detectors/_camera.py
+++ b/src/microsim/schema/detectors/_camera.py
@@ -82,7 +82,9 @@ class _Camera(SimBaseModel):
         self, total_electrons: npt.NDArray, xp: NumpyAPI
     ) -> npt.NDArray:
         voltage = xp.norm_rvs(total_electrons, self.read_noise) * self.gain
-        return xp.round((voltage / self.adc_gain) + self.offset)  # type: ignore
+        return xp.maximum(
+            xp.round((voltage / self.adc_gain) + self.offset), 0
+        )  # type: ignore
 
     def apply_post_quantization_binning(
         self, gray_values: npt.NDArray, binning: int, mode: str = "sum"

--- a/src/microsim/schema/detectors/_camera.py
+++ b/src/microsim/schema/detectors/_camera.py
@@ -82,9 +82,7 @@ class _Camera(SimBaseModel):
         self, total_electrons: npt.NDArray, xp: NumpyAPI
     ) -> npt.NDArray:
         voltage = xp.norm_rvs(total_electrons, self.read_noise) * self.gain
-        return xp.maximum(
-            xp.round((voltage / self.adc_gain) + self.offset), 0
-        )  # type: ignore
+        return xp.maximum(xp.round((voltage / self.adc_gain) + self.offset), 0)  # type: ignore
 
     def apply_post_quantization_binning(
         self, gray_values: npt.NDArray, binning: int, mode: str = "sum"


### PR DESCRIPTION
### Description

This PR proposes a one-line change in `quantize_electrons()` method of `_Camera`.
Specifically, it restricts the output to only contain positive values. Negative values can be introduced by the random sampling from the Gaussian distribution simulating the read-out noise.

### Motivation
- A negative value of intensity is not physically realistic.
- In the step after, array is casted to `uint`. Hence, all negative values are mapped to large numbers in the `uint` range (e.g., -1 --> 65534, etc., etc.). As a result, in the casted image we see some extremely bright dots in correspondence of what were the negative values before casting.  