### PR TITLE
feat: LRU Caching for PSF, ability to set cache size with envvar

### DIFF
--- a/src/microsim/psf.py
+++ b/src/microsim/psf.py
@@ -396,7 +396,7 @@ def make_psf(
 
 
 # variant of make_psf that only accepts hashable arguments
-@lru_cache(maxsize=Settings().in_mem_psf_cache_size)
+@lru_cache(maxsize=Settings().cache.in_mem_size.psf)
 def cached_psf(
     nz: int,
     nx: int,

--- a/src/microsim/psf.py
+++ b/src/microsim/psf.py
@@ -27,6 +27,7 @@ IN_MEM_PSF_CACHE_SIZE = int(
 )
 logging.info(f"In-memory PSF cache size has been set to: {IN_MEM_PSF_CACHE_SIZE}.")
 
+
 def simpson(
     objective: ObjectiveLens,
     theta: np.ndarray,

--- a/src/microsim/psf.py
+++ b/src/microsim/psf.py
@@ -11,7 +11,7 @@ import tqdm
 
 from microsim.schema.backend import NumpyAPI
 from microsim.schema.lens import ObjectiveKwargs, ObjectiveLens
-from microsim.schema.settings import IN_MEM_PSF_CACHE_SIZE_DEFAULT
+from microsim.schema.settings import Settings
 from microsim.util import microsim_cache
 
 from ._data_array import ArrayProtocol
@@ -21,11 +21,6 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from microsim._data_array import ArrayProtocol
-
-IN_MEM_PSF_CACHE_SIZE = int(
-    os.getenv("MICROSIM_IN_MEM_PSF_CACHE_SIZE", IN_MEM_PSF_CACHE_SIZE_DEFAULT)
-)
-logging.info(f"In-memory PSF cache size has been set to: {IN_MEM_PSF_CACHE_SIZE}.")
 
 
 def simpson(
@@ -401,7 +396,7 @@ def make_psf(
 
 
 # variant of make_psf that only accepts hashable arguments
-@lru_cache(maxsize=IN_MEM_PSF_CACHE_SIZE)
+@lru_cache(maxsize=Settings().in_mem_psf_cache_size)
 def cached_psf(
     nz: int,
     nx: int,

--- a/src/microsim/psf.py
+++ b/src/microsim/psf.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
-from functools import cache
+from functools import cache, lru_cache
 from typing import TYPE_CHECKING, Literal
 
 import numpy as np
@@ -11,6 +11,7 @@ import tqdm
 
 from microsim.schema.backend import NumpyAPI
 from microsim.schema.lens import ObjectiveKwargs, ObjectiveLens
+from microsim.schema.settings import IN_MEM_PSF_CACHE_SIZE_DEFAULT
 from microsim.util import microsim_cache
 
 from ._data_array import ArrayProtocol
@@ -21,6 +22,10 @@ if TYPE_CHECKING:
 
     from microsim._data_array import ArrayProtocol
 
+IN_MEM_PSF_CACHE_SIZE = int(
+    os.getenv("MICROSIM_IN_MEM_PSF_CACHE_SIZE", IN_MEM_PSF_CACHE_SIZE_DEFAULT)
+)
+logging.info(f"In-memory PSF cache size has been set to: {IN_MEM_PSF_CACHE_SIZE}.")
 
 def simpson(
     objective: ObjectiveLens,
@@ -395,7 +400,7 @@ def make_psf(
 
 
 # variant of make_psf that only accepts hashable arguments
-@cache
+@lru_cache(maxsize=IN_MEM_PSF_CACHE_SIZE)
 def cached_psf(
     nz: int,
     nx: int,

--- a/src/microsim/schema/settings.py
+++ b/src/microsim/schema/settings.py
@@ -9,6 +9,7 @@ from microsim._field_types import FloatDtype
 from ._base_model import SimBaseModel
 from .backend import BackendName, DeviceName, NumpyAPI
 
+IN_MEM_PSF_CACHE_SIZE_DEFAULT = 64
 
 class CacheSettings(SimBaseModel):
     read: bool = True
@@ -44,6 +45,15 @@ class Settings(SimBaseModel, BaseSettings):
         ),
     )
     cache: CacheSettings = Field(default_factory=CacheSettings)
+    in_mem_psf_cache_size: int = Field(
+        default=IN_MEM_PSF_CACHE_SIZE_DEFAULT, 
+        description=(
+            "The maximum number of PSFs that will be stored in the in-memory cache, "
+            "which follows the LRU caching strategy. Note, this setting will only take "
+            "effect if it is set as an environment variable, the default is "
+            f"{IN_MEM_PSF_CACHE_SIZE_DEFAULT}."
+        )
+    )
     spectral_bins_per_emission_channel: int = Field(
         1,
         description="Number of wavelengths to use (per channel) when simulating the "

--- a/src/microsim/schema/settings.py
+++ b/src/microsim/schema/settings.py
@@ -51,9 +51,10 @@ class Settings(SimBaseModel, BaseSettings):
         description=(
             "The maximum number of PSFs that will be stored in the in-memory cache, "
             "which follows the LRU caching strategy. Note, this setting will only take "
-            "effect if it is set as an environment variable, the default is "
-            f"{IN_MEM_PSF_CACHE_SIZE_DEFAULT}."
+            "effect by modifying the equivalent environment variable prior to "
+            f"importing microsim, the default is {IN_MEM_PSF_CACHE_SIZE_DEFAULT}."
         ),
+        frozen=True,
     )
     spectral_bins_per_emission_channel: int = Field(
         1,

--- a/src/microsim/schema/settings.py
+++ b/src/microsim/schema/settings.py
@@ -9,8 +9,6 @@ from microsim._field_types import FloatDtype
 from ._base_model import SimBaseModel
 from .backend import BackendName, DeviceName, NumpyAPI
 
-IN_MEM_PSF_CACHE_SIZE_DEFAULT = 64
-
 
 class CacheSettings(SimBaseModel):
     read: bool = True
@@ -47,12 +45,12 @@ class Settings(SimBaseModel, BaseSettings):
     )
     cache: CacheSettings = Field(default_factory=CacheSettings)
     in_mem_psf_cache_size: int = Field(
-        default=IN_MEM_PSF_CACHE_SIZE_DEFAULT,
+        default=64,
         description=(
             "The maximum number of PSFs that will be stored in the in-memory cache, "
             "which follows the LRU caching strategy. Note, this setting will only take "
             "effect by modifying the equivalent environment variable prior to "
-            f"importing microsim, the default is {IN_MEM_PSF_CACHE_SIZE_DEFAULT}."
+            f"importing microsim."
         ),
         frozen=True,
     )

--- a/src/microsim/schema/settings.py
+++ b/src/microsim/schema/settings.py
@@ -11,9 +11,7 @@ from .backend import BackendName, DeviceName, NumpyAPI
 
 
 class InMemoryCacheSizes(SimBaseModel):
-    """
-    Parameters that control the in-memory cache size of various cached functions.
-    """
+    """Parameters that control the in-memory cache size of various cached functions."""
 
     psf: int = Field(
         default=64,

--- a/src/microsim/schema/settings.py
+++ b/src/microsim/schema/settings.py
@@ -11,6 +11,7 @@ from .backend import BackendName, DeviceName, NumpyAPI
 
 IN_MEM_PSF_CACHE_SIZE_DEFAULT = 64
 
+
 class CacheSettings(SimBaseModel):
     read: bool = True
     write: bool = True
@@ -46,13 +47,13 @@ class Settings(SimBaseModel, BaseSettings):
     )
     cache: CacheSettings = Field(default_factory=CacheSettings)
     in_mem_psf_cache_size: int = Field(
-        default=IN_MEM_PSF_CACHE_SIZE_DEFAULT, 
+        default=IN_MEM_PSF_CACHE_SIZE_DEFAULT,
         description=(
             "The maximum number of PSFs that will be stored in the in-memory cache, "
             "which follows the LRU caching strategy. Note, this setting will only take "
             "effect if it is set as an environment variable, the default is "
             f"{IN_MEM_PSF_CACHE_SIZE_DEFAULT}."
-        )
+        ),
     )
     spectral_bins_per_emission_channel: int = Field(
         1,

--- a/src/microsim/schema/settings.py
+++ b/src/microsim/schema/settings.py
@@ -10,9 +10,27 @@ from ._base_model import SimBaseModel
 from .backend import BackendName, DeviceName, NumpyAPI
 
 
+class InMemoryCacheSizes(SimBaseModel):
+    """
+    Parameters that control the in-memory cache size of various cached functions.
+    """
+
+    psf: int = Field(
+        default=64,
+        description=(
+            "The maximum number of PSFs that will be stored in the in-memory cache, "
+            "which follows the LRU caching strategy. Note, this setting will only take "
+            "effect by modifying the equivalent environment variable prior to "
+            "importing microsim."
+        ),
+        frozen=True,
+    )
+
+
 class CacheSettings(SimBaseModel):
     read: bool = True
     write: bool = True
+    in_mem_size: InMemoryCacheSizes = Field(default_factory=InMemoryCacheSizes)
 
     @model_validator(mode="before")
     @classmethod
@@ -44,16 +62,6 @@ class Settings(SimBaseModel, BaseSettings):
         ),
     )
     cache: CacheSettings = Field(default_factory=CacheSettings)
-    in_mem_psf_cache_size: int = Field(
-        default=64,
-        description=(
-            "The maximum number of PSFs that will be stored in the in-memory cache, "
-            "which follows the LRU caching strategy. Note, this setting will only take "
-            "effect by modifying the equivalent environment variable prior to "
-            "importing microsim."
-        ),
-        frozen=True,
-    )
     spectral_bins_per_emission_channel: int = Field(
         1,
         description="Number of wavelengths to use (per channel) when simulating the "

--- a/src/microsim/schema/settings.py
+++ b/src/microsim/schema/settings.py
@@ -50,7 +50,7 @@ class Settings(SimBaseModel, BaseSettings):
             "The maximum number of PSFs that will be stored in the in-memory cache, "
             "which follows the LRU caching strategy. Note, this setting will only take "
             "effect by modifying the equivalent environment variable prior to "
-            f"importing microsim."
+            "importing microsim."
         ),
         frozen=True,
     )


### PR DESCRIPTION
This PR decorates the `microsim.psf.cached_psf` with `functools.lru_cache` rather than `cache`. This is to stop memory usage increasing indefinitely if a large number of images are being generated. Additionally, the max size of the cache can be set with an environment variable.

**Notes:** 
- I added the variable to the settings, mostly for documentation, but it will not change the cache size if set here. The cache size can only be modified with an environment variable since the cache size is set at import. I looked up a few ugly work arounds that involve wrapping the function or redecorating the function dynamically, but I decided the current solution was adequate. 
- I added `in_mem_psf_cache_size` to `Settings` and not `CacheSettings` because it seemed to me `CacheSettings` relates more to the cache on disk. But I can move it if you think it's better.

Closes #97 

### Changes
- Added `IN_MEM_PSF_CACHE_SIZE_DEFAULT` variable to `microsim/schema/settings.py`
- Added `in_mem_psf_cache_size` field to `Settings`
- Added mechanism to get default or environment variable size in `microsim/psf.py`
- Modified `cache` decorator to `lru_cache` decorator on `microsim.psf.cached_psf`.
