### PR TITLE
fix: make cosem import optional

### DIFF
--- a/src/microsim/schema/__init__.py
+++ b/src/microsim/schema/__init__.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any
 
 from .backend import BackendName, DeviceName, NumpyAPI
 from .detectors import CameraCCD, CameraCMOS, CameraEMCCD
@@ -12,7 +13,7 @@ from .optical_config import (
     Shortpass,
     SpectrumFilter,
 )
-from .sample import CosemLabel, Fluorophore, FluorophoreDistribution, MatsLines, Sample
+from .sample import Fluorophore, FluorophoreDistribution, MatsLines, Sample
 from .settings import Settings
 from .simulation import Simulation
 from .space import DownscaledSpace, ExtentScaleSpace, ShapeExtentSpace, ShapeScaleSpace
@@ -50,3 +51,10 @@ __all__ = [
     "SpectrumFilter",
     "Widefield",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "CosemLabel":
+        from .sample import CosemLabel
+        return CosemLabel
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/microsim/schema/__init__.py
+++ b/src/microsim/schema/__init__.py
@@ -56,5 +56,6 @@ __all__ = [
 def __getattr__(name: str) -> Any:
     if name == "CosemLabel":
         from .sample import CosemLabel
+
         return CosemLabel
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/microsim/schema/sample/__init__.py
+++ b/src/microsim/schema/sample/__init__.py
@@ -1,5 +1,4 @@
 from ._distributions._base import BaseDistribution
-from ._distributions.cosem import CosemLabel
 from ._distributions.matslines import MatsLines
 from .fluorophore import Fluorophore
 from .sample import AnyDistribution, FluorophoreDistribution, Sample
@@ -13,3 +12,10 @@ __all__ = [
     "MatsLines",
     "Sample",
 ]
+
+
+def __getattr__(name: str):
+    if name == "CosemLabel":
+        from ._distributions.cosem import CosemLabel
+        return CosemLabel
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/microsim/schema/sample/__init__.py
+++ b/src/microsim/schema/sample/__init__.py
@@ -17,5 +17,6 @@ __all__ = [
 def __getattr__(name: str):
     if name == "CosemLabel":
         from ._distributions.cosem import CosemLabel
+
         return CosemLabel
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/microsim/schema/sample/sample.py
+++ b/src/microsim/schema/sample/sample.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 import numpy as np
 from pydantic import Field, model_validator
@@ -10,14 +10,35 @@ from microsim.schema.backend import NumpyAPI
 from microsim.schema.spectrum import Spectrum
 
 from ._distributions._base import Renderable, RenderableType
-from ._distributions.cosem import CosemLabel
 from ._distributions.direct import FixedArrayTruth
 from ._distributions.matslines import MatsLines
 from .fluorophore import Fluorophore
 
-AnyDistribution = MatsLines | CosemLabel | FixedArrayTruth | RenderableType
-# TODO: this feels like an unDRY hack
-DistributionTypes = MatsLines | CosemLabel | FixedArrayTruth | Renderable
+if TYPE_CHECKING:
+    from ._distributions.cosem import CosemLabel
+    AnyDistribution = (
+        MatsLines 
+        | CosemLabel 
+        | FixedArrayTruth 
+        | RenderableType
+    )
+    DistributionTypes = (
+        MatsLines 
+        | CosemLabel 
+        | FixedArrayTruth 
+        | Renderable
+    )
+else:
+    AnyDistribution = (
+        MatsLines 
+        | FixedArrayTruth 
+        | RenderableType
+    )
+    DistributionTypes = (
+        MatsLines 
+        | FixedArrayTruth 
+        | Renderable
+    )
 
 # This is a placeholder fluorophore for when no fluorophore is specified
 # it has broad excitation and emission spectra, high extinction coefficient.

--- a/src/microsim/schema/sample/sample.py
+++ b/src/microsim/schema/sample/sample.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from pydantic import Field, model_validator
@@ -16,29 +16,12 @@ from .fluorophore import Fluorophore
 
 if TYPE_CHECKING:
     from ._distributions.cosem import CosemLabel
-    AnyDistribution = (
-        MatsLines 
-        | CosemLabel 
-        | FixedArrayTruth 
-        | RenderableType
-    )
-    DistributionTypes = (
-        MatsLines 
-        | CosemLabel 
-        | FixedArrayTruth 
-        | Renderable
-    )
+
+    AnyDistribution = MatsLines | CosemLabel | FixedArrayTruth | RenderableType
+    DistributionTypes = MatsLines | CosemLabel | FixedArrayTruth | Renderable
 else:
-    AnyDistribution = (
-        MatsLines 
-        | FixedArrayTruth 
-        | RenderableType
-    )
-    DistributionTypes = (
-        MatsLines 
-        | FixedArrayTruth 
-        | Renderable
-    )
+    AnyDistribution = MatsLines | FixedArrayTruth | RenderableType
+    DistributionTypes = MatsLines | FixedArrayTruth | Renderable
 
 # This is a placeholder fluorophore for when no fluorophore is specified
 # it has broad excitation and emission spectra, high extinction coefficient.


### PR DESCRIPTION
Fixed "ImportError: To use COSEM data, please `pip install microsim[cosem]`". 
Occurred because the code was trying to use CosemLabel which is part of the COSEM-specific functionality, but we hadn't installed the COSEM dependencies yet when running `pip install microsim`.

Two changes: 
- added matplotlib and zarr as core dependencies (to use orthplot)
- made cosem an "optional dependencies" with try-catch blocks in the init files to handle the absence of cosem

package should now be working for non-COSEM cases. If COSEM is needed, one can install with the [cosem] flag.