### PR TITLE
tests: allow to work without internet

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,8 +9,8 @@ repos:
     hooks:
       - id: validate-pyproject
 
-  - repo: https://github.com/crate-ci/typos
-    rev: v1
+  - repo: https://github.com/adhtruong/mirrors-typos
+    rev: v1.35.5
     hooks:
       - id: typos
         args: [--force-exclude]  # omitting --write-changes

--- a/tests/_util.py
+++ b/tests/_util.py
@@ -1,0 +1,19 @@
+import socket
+from collections.abc import Callable
+
+import pytest
+
+try:
+    socket.create_connection(("8.8.8.8", 53), timeout=1)
+    HAVE_INTERNET = True
+except OSError:
+    HAVE_INTERNET = False
+
+
+def skipif_no_internet(func: Callable) -> Callable:
+    # if there is no internet...
+
+    if not HAVE_INTERNET:
+        func = pytest.mark.skip("No internet connection")(func)
+
+    return func

--- a/tests/test_allen.py
+++ b/tests/test_allen.py
@@ -2,8 +2,11 @@ import numpy as np
 
 from microsim.allen import NeuronReconstruction, Specimen
 
+from ._util import skipif_no_internet
 
-def test_neuron_reconstruction():
+
+@skipif_no_internet
+def test_neuron_reconstruction() -> None:
     nr = NeuronReconstruction.fetch(638976782)
 
     mask = nr.binary_mask()
@@ -16,7 +19,8 @@ def test_neuron_reconstruction():
     assert swc.origin() == (root.z, root.y, root.x)
 
 
-def test_specimen():
+@skipif_no_internet
+def test_specimen() -> None:
     spec = Specimen.fetch(586073850)
     masks = spec.binary_masks()
     assert len(masks) == len(spec.neuron_reconstructions)

--- a/tests/test_cosem.py
+++ b/tests/test_cosem.py
@@ -7,6 +7,8 @@ import tensorstore as ts
 from microsim import schema as ms
 from microsim.schema.optical_config import lib
 
+from ._util import skipif_no_internet
+
 try:
     from microsim.cosem import CosemDataset, CosemImage, CosemView, manage, organelles
 except ImportError:
@@ -16,6 +18,7 @@ except ImportError:
     )
 
 
+@skipif_no_internet
 def test_cosem_dataset(monkeypatch: pytest.MonkeyPatch) -> None:
     dataset = CosemDataset.fetch("jrc_hela-3")
     assert dataset in CosemDataset.all().values()
@@ -36,6 +39,7 @@ def test_cosem_dataset(monkeypatch: pytest.MonkeyPatch) -> None:
         dataset.read(("fibsem-uint16", "er_seg"), level=-1)
 
 
+@skipif_no_internet
 def test_cosem_image() -> None:
     # note, this is also testing _get_similar ... since the "real" name is jrc_hela-3
     dataset = CosemDataset.fetch("jrc_hela_3")
@@ -49,6 +53,7 @@ def test_cosem_image() -> None:
         img = dataset.image(name="not real")
 
 
+@skipif_no_internet
 def test_cosem_view() -> None:
     orgs = organelles()
     assert "Centrosome" in orgs
@@ -61,6 +66,7 @@ def test_cosem_view() -> None:
     assert CosemDataset.fetch("jrc_hela-2").view("Centrosome") == first_view
 
 
+@skipif_no_internet
 def test_cosem_manage(monkeypatch: pytest.MonkeyPatch) -> None:
     with monkeypatch.context() as m:
         m.setattr(sys, "argv", ["", "--help"])
@@ -81,6 +87,7 @@ def test_cosem_manage(monkeypatch: pytest.MonkeyPatch) -> None:
         manage.main()
 
 
+@skipif_no_internet
 def test_cosem_simulation() -> None:
     sim = ms.Simulation(
         truth_space=ms.ShapeScaleSpace(shape=(32, 256, 256), scale=(0.64, 0.64, 0.64)),

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -5,11 +5,16 @@ from textwrap import dedent
 
 import pytest
 
+from ._util import HAVE_INTERNET
+
 DOCS = Path(__file__).parent.parent / "docs"
 DOCS_MDS = list(DOCS.rglob("*.md"))
 DOCS_MDS += [Path(__file__).parent.parent / "README.md"]
 CODE_BLOCK = re.compile(r"```python([^`]*)```", re.DOTALL)
 JSON_BLOCK = re.compile(r"```json([^`]*)```", re.DOTALL)
+
+if not HAVE_INTERNET:
+    DOCS_MDS = [p for p in DOCS_MDS if p.name not in {"stages.md"}]
 
 
 @pytest.mark.parametrize("doc", DOCS_MDS, ids=lambda p: p.name)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from microsim import util
+from tests._util import skipif_no_internet
 
 EXAMPLE_DIR = Path(__file__).parent.parent / "examples/"
 skip = {
@@ -19,6 +20,7 @@ examples = [
 ]
 
 
+@skipif_no_internet
 @pytest.mark.usefixtures("mpl_show_patch")
 @pytest.mark.parametrize("fpath", examples, ids=lambda x: x.name)
 def test_examples(fpath: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -1,8 +1,10 @@
 import pytest
 
 from microsim.schema import Fluorophore, OpticalConfig, Simulation, SpectrumFilter
+from tests._util import skipif_no_internet
 
 
+@skipif_no_internet
 def test_plot_oc() -> None:
     pytest.importorskip("matplotlib")
     Fluorophore.from_fpbase("EGFP").plot(show=False)


### PR DESCRIPTION
this PR skips tests that require the internet if no internet is detected.

it's a stop gap to creating properly mocked tests