### PR TITLE
fix: Aggregation of fluorphores in ground truth with multiple samples

### DIFF
--- a/src/microsim/schema/simulation.py
+++ b/src/microsim/schema/simulation.py
@@ -119,10 +119,6 @@ class Simulation(SimBaseModel):
         if not hasattr(self, "_ground_truth"):
             with logging_indented():
                 xp = self._xp
-                # make empty space into which we'll add the ground truth
-                # TODO: this is wasteful... label.render should probably
-                # accept the space object directly
-                truth = self.truth_space.create(array_creator=xp.zeros)
 
                 # render each ground truth
                 label_data = []
@@ -138,6 +134,10 @@ class Simulation(SimBaseModel):
                             f"Loaded ground truth for {label} from cache: {cache_path}"
                         )
                     else:
+                        # make empty space into which we'll add the ground truth
+                        # TODO: this is wasteful... label.render should probably
+                        # accept the space object directly
+                        truth = self.truth_space.create(array_creator=xp.zeros)
                         data = label.render(truth, xp=xp)
                         if self.settings.cache.write and cache_path:
                             to_cache(data, cache_path, dtype=np.uint16)


### PR DESCRIPTION
I found a bug where if you have multiple `FlurophoreDistribution` instances in the `Sample`, the number of fluorophores will be multiplied by the number of samples. This was happening because the same space was being given to each distribution to render into, which would result in n copies of the space for n samples, which would then be summed together. I fixed this by creating a new space for each distribution during the ground truth generation.

### Below shows a demo of the behaviour before the fix and after:

```python 
import numpy as np
import matplotlib.pyplot as plt

import microsim.schema as ms
from microsim._data_array import xrDataArray
from microsim.schema.backend import NumpyAPI
```

<details>
<summary>Renderable Ball class used in demo</summary>

```python
class Ball:

    def __init__(self, centre: tuple[float, float, float], radius: float):
        """
        Renderable class that generates a ball for the given `centre` and `radius`.

        Parameters
        ----------
        centre : tuple[float, float, float]
            The centre of the ball in truth pixel units.
        radius : float
            The radius of the ball in truth pixel units.
        """
        self.centre = np.array(centre)
        self.radius = radius

    def render(self, space: xrDataArray, xp: NumpyAPI | None = None) -> xrDataArray:
        xp = xp or NumpyAPI()
        shape = np.array(space.shape)
        centre = self.centre

        ii, jj, kk = np.mgrid[: shape[0], : shape[1], : shape[2]]
        space += xp.asarray(
            (
                (ii - centre[0]) ** 2 + (jj - centre[1]) ** 2 + (kk - centre[2]) ** 2
                <= self.radius**2
            ).astype(float)
        )
        return space
```
</details>

#### Before

```python
>>> sim = ms.Simulation(
        truth_space=ms.space.ShapeScaleSpace(shape=(24, 64, 128), scale=(0.04, 0.02, 0.02)),
        output_space=ms.space.DownscaledSpace(downscale=4),
        sample=[
            ms.FluorophoreDistribution(distribution=Ball(centre=(12, 32, 32), radius=32)),
            ms.FluorophoreDistribution(distribution=Ball(centre=(12, 32, 128-32+1), radius=32))
        ]
    )
>>> img = sim.digital_image()
... img.data.min(), img.data.max()
(28.87027282714844, 462.57768554687505)

>>> gt = sim.ground_truth()
... gt.shape
(2, 24, 64, 128)

>>> fig, axes=plt.subplots(2, 1)
... axes[0].imshow(gt.data[0, 12])
... axes[1].imshow(gt.data[1, 12]
... fig.suptitle("Behaviour before")
```
<img width="383" height="461" alt="aacb3436-aa75-4007-bd4b-c764d74468a0" src="https://github.com/user-attachments/assets/5cd02fa0-df39-4177-b0fd-9863999018c0" />

#### After
(simulation parameters kept the same)

```python
>>> img.data.min(), img.data.max()
(14.435137939453126, 231.28884277343752)
```
<img width="383" height="461" alt="e7714503-fb2d-4c3b-9d96-de120f202ae4" src="https://github.com/user-attachments/assets/30570121-c4ac-4b0e-8598-cb56424c2eeb" />

As you can see the min and max values before the fix are roughly double the image values after the fix because I had two distributions being simulated.