### PR TITLE
fix: support zarr3 format

### DIFF
--- a/src/microsim/cosem/_tstore.py
+++ b/src/microsim/cosem/_tstore.py
@@ -32,6 +32,7 @@ DRIVERS = {
     "precomputed": "neuroglancer_precomputed",
     "n5": "n5",
     "zarr": "zarr",
+    "zarr3": "zarr3",
 }
 
 

--- a/src/microsim/cosem/models.py
+++ b/src/microsim/cosem/models.py
@@ -104,8 +104,11 @@ class CosemImage(BaseModel):
         """Fetch all available scales for the image from s3."""
         if not getattr(self, "_scales", None):
             scales = []
+            # n5/zarr v2 multiscale lives at the top level, while zarr v3
+            # (OME-NGFF 0.5) nests it under the "ome" namespace.
+            ome = self.attrs.get("ome", {})
             # n5 multiscale
-            if multi := self.attrs.get("multiscales"):
+            if multi := (self.attrs.get("multiscales") or ome.get("multiscales")):
                 for scale in multi:
                     if dsets := scale.get("datasets"):
                         for dset in dsets:
@@ -185,10 +188,16 @@ class CosemImage(BaseModel):
                 attr = "/attributes.json"
             elif self.format == "zarr":
                 attr = "/.zattrs"
+            elif self.format == "zarr3":
+                attr = "/zarr.json"
             elif self.format == "precomputed":
                 attr = "/info"
             try:
-                self._attrs = json.load(fetch_s3(self.url + attr))
+                data = json.load(fetch_s3(self.url + attr))
+                # zarr v3 nests user attributes under an "attributes" namespace
+                if self.format == "zarr3":
+                    data = data.get("attributes", {})
+                self._attrs = data
             except Exception:
                 self._attrs = {}
         return self._attrs  # type: ignore [no-any-return]

--- a/src/microsim/cosem/models.py
+++ b/src/microsim/cosem/models.py
@@ -38,6 +38,7 @@ ContentType = Literal[
 ImageFormat = Literal[
     "n5",
     "zarr",
+    "zarr3",
     "precomputed",
     "neuroglancer_precomputed",
     "neuroglancer_multilod_draco",

--- a/tests/test_cosem.py
+++ b/tests/test_cosem.py
@@ -54,6 +54,20 @@ def test_cosem_image() -> None:
 
 
 @skipif_no_internet
+def test_cosem_zarr3() -> None:
+    # COSEM now serves some images as zarr v3; make sure we can validate,
+    # resolve scales, and read them. See #140 / #141.
+    dataset = CosemDataset.fetch("jrc_mus-skel-muscle-1")
+    img = dataset.image(name="fibsem-uint8")
+    assert img.format == "zarr3"
+    assert img.scales  # multiscale metadata nested under the "ome" namespace
+    # read a mid-pyramid level (all dims > 1) to exercise the zarr3 driver
+    store = img.read(level=8, bin_mode="standard")
+    assert isinstance(store, ts.TensorStore)
+    assert store.ndim == 3
+
+
+@skipif_no_internet
 def test_cosem_view() -> None:
     orgs = organelles()
     assert "Centrosome" in orgs


### PR DESCRIPTION
The COSEM API now returns `format: "zarr3"` for some images, which
the pydantic `ImageFormat` literal rejected as invalid. Hit this
while pulling `jrc_hela-3` / `er-mem_pred` to validate #124 against
real data — unrelated to that fix, splitting out separately.